### PR TITLE
Issue #33: Make App a subclass of Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,32 @@
 
 For the main packages:
 
-| Package      | PyPi                 | Ubuntu/Debian  | Source                                |
-| ------------ | -------------------- | -------------- | ------------------------------------- |
-| pyyaml       | `pip install pyyAML` | `python3-yaml` | https://github.com/yaml/pyyaml        |
-| py_mmd_tools | N/A                  | N/A            | https://github.com/metno/py-mmd-tools |
+| Package      | PyPi                   | Ubuntu/Debian      | Source                                |
+| ------------ | ---------------------- | ------------------ | ------------------------------------- |
+| requests     | `pip install requests` | `python3-requests` | https://github.com/psf/requests       |
+| pyyaml       | `pip install pyyaml`   | `python3-yaml`     | https://github.com/yaml/pyyaml        |
+| flask        | `pip install flask`    | `python3-flask`    | https://github.com/pallets/flask      |
+| lxml         | `pip install lxml`     | `python3-lxml`     | https://github.com/lxml/lxml          |
 
-**Note:** The package `py_mmd_tools` is not on pip, but running the install for the requirements
-file will also install this directly from the repository:
+In addition, the tool `pythesint` must be installed from
+[github.com/metno/py-thesaurus-interface](https://github.com/metno/py-thesaurus-interface).
+
+The requirements can also be installed with:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Environment Variables
+
+The package reads the following environment variables.
+
+* `DMCI_CONFIG` should point to the config file, in yaml format.
+* `DMCI_LOGFILE` can be set to enable logging to file.
+* `DMCI_LOGLEVEL` can be set to change log level. See the Debugging section below.
+
+If the config variable is not set, the package will look for a file named `config.yaml` at the
+package root location. If neither the environment variable is set, or this file exists, the
+initialisation will fail and exit with exit code `1`.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ initialisation will fail and exit with exit code `1`.
 
 The tests use `pytest`. To run all tests for all modules, run:
 ```bash
-pytest-3 -vv
+python -m pytest -vv
 ```
 
 To add coverage, and to optionally generate a coverage report in HTML, run:
 ```bash
-pytest-3 -vv --cov=dmci --cov-report=term --cov-report=html
+python -m pytest -vv --cov=dmci --cov-report=term --cov-report=html
 ```
 Coverage requires the `pytest-cov` package.
 

--- a/dmci/api/README.md
+++ b/dmci/api/README.md
@@ -1,3 +1,0 @@
-# Testing the program
-
-`curl --data "@tests/files/test.xml" localhost:5000/v1/insert`

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -30,22 +30,18 @@ from dmci.api.worker import Worker
 
 logger = logging.getLogger(__name__)
 
-class App():
+class App(Flask):
 
     def __init__(self):
-        self._app = Flask(__name__)
+        super().__init__(__name__)
         self._conf = dmci.CONFIG
 
         if self._conf.distributor_cache is None:
             logger.error("Parameter distributor_cache in config is not set")
             sys.exit(1)
 
-        # Forward functions
-        self.run = self._app.run
-        self.test_client = self._app.test_client
-
         # Set up api entry points
-        @self._app.route("/v1/insert", methods=["POST"])
+        @self.route("/v1/insert", methods=["POST"])
         def base():
             max_permitted_size = self._conf.max_permitted_size
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=5.2.0
+pytest-cov>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests
 pythesint @ git+https://github.com/metno/py-thesaurus-interface@f43f9ec70131fcbb46f129ea566a0ca241b3ba67
-pyyaml
-flask
-lxml
+requests>=2.22
+pyyaml>=5.1
+flask>=1.0
+lxml>=4.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ python_requires = >=3.6
 include_package_data = True
 packages = find:
 scripts = dmci_start_api.py
-test_suite = tests
 install_requires =
     requests
     pythesint @ git+https://github.com/metno/py-thesaurus-interface@f43f9ec70131fcbb46f129ea566a0ca241b3ba67

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,11 +31,11 @@ include_package_data = True
 packages = find:
 scripts = dmci_start_api.py
 install_requires =
-    requests
     pythesint @ git+https://github.com/metno/py-thesaurus-interface@f43f9ec70131fcbb46f129ea566a0ca241b3ba67
-    pyyaml
-    flask
-    lxml
+    requests>=2.22
+    pyyaml>=5.1
+    flask>=1.0
+    lxml>=4.2.0
 
 [options.data_files]
 usr/share/doc/dmci =


### PR DESCRIPTION
**Summary**:

Making the class `App` a subclass of `Flask` simplifies a few things, so here it is.
The same PR also updates the main README.

**Related issue**:

Resolves #33 

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.