### PR TITLE
Add simple run-example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ curl --data "@<PATH_TO_MMD_FILE>" localhost:5000/v1/insert
 ```
 insert is currently the only implemented command. Other commands will return 404 Not Found until implementation.
 
-The API uses HTML return codes, and expected returns are:
+The API uses HTTP return codes, and expected returns are:
 
     200 for validated and queued requests.
     404 for non-implemented commands.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ To increase logging level to include info and debug messages, set the environmen
 `DMCI_LOGLEVEL` to the desired level. Valid levels are `CRITICAL`, `ERROR`, `WARNING`, `INFO`, and
 `DEBUG`.
 
+## Usage
+
+First initialize the config.yaml or use environment-variables. Then, to start the API run:
+
+```python
+python dmci_start_api.py
+```
+
+Then you can post with curl to the api - endpoint:
+
+```bash
+curl --data "@<PATH_TO_MMD_FILE>" localhost:5000/v1/insert
+```
+insert is currently the only implemented command. Other commands will return 
+
 ## Licence
 
 Copyright 2021 MET Norway

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ Then you can post with curl to the api - endpoint:
 ```bash
 curl --data "@<PATH_TO_MMD_FILE>" localhost:5000/v1/insert
 ```
-insert is currently the only implemented command. Other commands will return 
+insert is currently the only implemented command. Other commands will return 404 Not Found until implementation.
+
+The API uses HTML return codes, and expected returns are:
+
+    200 for validated and queued requests.
+    404 for non-implemented commands.
+    413 for files being bigger than treshold (Default is 10MB, given as max_permitted_size)
+    500 for validation errors and other internal server problems
+    507 if file could not be saved to the work queue
 
 ## Licence
 


### PR DESCRIPTION
**Summary**: Adds documentation how to send a file with curl to the insert endpoint

**Related issue**: Closes #45

**Suggested reviewer(s)**: @aheimsbakk 

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.