### PR TITLE
XML fixes to dist_pycsw

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,6 +27,8 @@ jobs:
           pip install pytest-timeout
           pip install pytest-cov
       - name: Run Tests
-        run: python -m pytest -v --cov=dmci --timeout=60 -m 'not mmd_tools'
+        run: |
+          export DMCI_LOGLEVEL=DEBUG
+          python -m pytest -v --cov=dmci --timeout=60 -m 'not mmd_tools'
       - name: Upload to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,8 +27,6 @@ jobs:
           pip install pytest-timeout
           pip install pytest-cov
       - name: Run Tests
-        run: |
-          export DMCI_LOGLEVEL=DEBUG
-          python -m pytest -v --cov=dmci --timeout=60 -m 'not mmd_tools'
+        run: python -m pytest -v --cov=dmci --timeout=60 -m 'not mmd_tools'
       - name: Upload to Codecov
         uses: codecov/codecov-action@v1

--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -110,10 +110,11 @@ def testDistPyCSW_Delete(monkeypatch, mockXml):
 # END Test testDistPyCSW_Delete
 
 @pytest.mark.dist
-def testDistPyCSW_Translate(monkeypatch, mockXml, filesDir):
+def testDistPyCSW_Translate(filesDir, caplog):
     """_translate tests
     """
     passFile = os.path.join(filesDir, "api", "passing.xml")
+    failFile = os.path.join(filesDir, "not_an_xml_file.xml")
     xsltFile = os.path.join(filesDir, "mmd", "mmd-to-geonorge.xslt")
 
     outFile = os.path.join(filesDir, "reference", "passing_translated.xml")
@@ -122,6 +123,12 @@ def testDistPyCSW_Translate(monkeypatch, mockXml, filesDir):
     tstPyCSW = PyCSWDist("insert", xml_file=passFile)
     tstPyCSW._conf.mmd_xslt_path = xsltFile
     assert tstPyCSW._translate() == outData.encode("utf-8")
+
+    tstPyCSW = PyCSWDist("insert", xml_file=failFile)
+    tstPyCSW._conf.mmd_xslt_path = xsltFile
+    assert tstPyCSW._translate() == ""
+    assert caplog.messages[-2] == "Failed to translate MMD to ISO19139"
+    assert caplog.messages[-1].startswith("Input object has no document:")
 
 # END Test testDistPyCSW_Translate
 

--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -124,11 +124,11 @@ def testDistPyCSW_Translate(filesDir, caplog):
     tstPyCSW._conf.mmd_xslt_path = xsltFile
     assert tstPyCSW._translate() == outData.encode("utf-8")
 
+    caplog.clear()
     tstPyCSW = PyCSWDist("insert", xml_file=failFile)
     tstPyCSW._conf.mmd_xslt_path = xsltFile
     assert tstPyCSW._translate() == ""
-    assert caplog.messages[-2] == "Failed to translate MMD to ISO19139"
-    assert caplog.messages[-1].startswith("Input object has no document:")
+    assert "Failed to translate MMD to ISO19139" in caplog.messages
 
 # END Test testDistPyCSW_Translate
 
@@ -301,6 +301,7 @@ def testDistPyCSW_ReadResponse(mockXml, caplog):
     ) is False
 
     # delete unknown tag
+    caplog.clear()
     md_id = "S1A_EW_GRDM_1SDH_20200420T023244_20200420T023348_032205_03B97F_72EB"
     text = (
         '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
@@ -318,9 +319,10 @@ def testDistPyCSW_ReadResponse(mockXml, caplog):
     )._read_response_text(
         "total_deleted", text
     ) is False
-    assert caplog.messages[-1] == "This should not happen"
+    assert "This should not happen" in caplog.messages
 
     # insert but dataset already exists, unparsable error
+    caplog.clear()
     text = (
         '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
         '<!-- pycsw 2.7.dev0 -->'
@@ -335,9 +337,10 @@ def testDistPyCSW_ReadResponse(mockXml, caplog):
     )
     key = "total_inserted"
     assert PyCSWDist("insert", xml_file=mockXml)._read_response_text(key, text) is False
-    assert caplog.messages[-1] == "Unknown Error"
+    assert "Unknown Error" in caplog.messages
 
     # unparsable response (truncated)
+    caplog.clear()
     text = (
         '<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
         '<!-- pycsw 2.7.dev0 -->'
@@ -348,6 +351,6 @@ def testDistPyCSW_ReadResponse(mockXml, caplog):
     )
     key = "total_inserted"
     assert PyCSWDist("insert", xml_file=mockXml)._read_response_text(key, text) is False
-    assert caplog.messages[-1].startswith("AttValue:")
+    assert "Could not parse response XML from PyCSW" in caplog.messages
 
 # END Test testDistPyCSW_ReadResponse


### PR DESCRIPTION
**Summary**:

* Drop the `xml.dom.minidom` import and instead use `lxml.etree` like everywhere else. This also properly handles namespaces, which minidom does not.
* Make the response parser and translate functions safer to use by adding exception handling.
* Extend tests

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.