### PR TITLE
#62: conversion from bytes to string object should solve the issue..

### DIFF
--- a/dmci/distributors/pycsw_dist.py
+++ b/dmci/distributors/pycsw_dist.py
@@ -70,7 +70,8 @@ class PyCSWDist(Distributor):
             xml_doc = etree.ElementTree(file=self._xml_file)
             transform = etree.XSLT(etree.parse(self._conf.mmd_xslt_path))
             new_doc = transform(xml_doc)
-            result = etree.tostring(new_doc, pretty_print=False, encoding="utf-8")
+            # get bytes object and convert to string
+            result = etree.tostring(new_doc, pretty_print=False, encoding="utf-8").decode("utf-8")
         except Exception as e:
             logger.error("Failed to translate MMD to ISO19139")
             logger.debug(str(e))

--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -119,10 +119,11 @@ def testDistPyCSW_Translate(filesDir, caplog):
 
     outFile = os.path.join(filesDir, "reference", "pycsw_dist_translated.xml")
     outTree = etree.parse(outFile, parser=etree.XMLParser(remove_blank_text=True))
-    outData = etree.tostring(outTree, pretty_print=False, encoding="utf-8")
+    outData = etree.tostring(outTree, pretty_print=False, encoding="utf-8").decode("utf-8")
 
     tstPyCSW = PyCSWDist("insert", xml_file=passFile)
     tstPyCSW._conf.mmd_xslt_path = xsltFile
+    assert type(tstPyCSW._translate()) == str
     assert tstPyCSW._translate() == outData
 
     caplog.clear()


### PR DESCRIPTION
**Summary**: I think this should close #62...

**Related issue**: #62

**Suggested reviewer(s)**: @vkbo @aheimsbakk @TAlonglong 

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.