### PR TITLE
Make the xml translator work in bytes only

### DIFF
--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -53,7 +53,7 @@ def testDistPyCSW_Insert(monkeypatch, mockXml, mockXslt):
     """
     # insert returns True
     with monkeypatch.context() as mp:
-        mp.setattr(PyCSWDist, "_translate", lambda *a: "<xml />")
+        mp.setattr(PyCSWDist, "_translate", lambda *a: b"<xml />")
         mp.setattr(
             "dmci.distributors.pycsw_dist.requests.post", lambda *a, **k: "a response object"
         )
@@ -64,7 +64,7 @@ def testDistPyCSW_Insert(monkeypatch, mockXml, mockXslt):
 
     # insert returns false
     with monkeypatch.context() as mp:
-        mp.setattr(PyCSWDist, "_translate", lambda *a: "<xml />")
+        mp.setattr(PyCSWDist, "_translate", lambda *a: b"<xml />")
         mp.setattr(
             "dmci.distributors.pycsw_dist.requests.post", lambda *a, **k: "a response object"
         )
@@ -119,17 +119,18 @@ def testDistPyCSW_Translate(filesDir, caplog):
 
     outFile = os.path.join(filesDir, "reference", "pycsw_dist_translated.xml")
     outTree = etree.parse(outFile, parser=etree.XMLParser(remove_blank_text=True))
-    outData = etree.tostring(outTree, pretty_print=False, encoding="utf-8").decode("utf-8")
+    outData = etree.tostring(outTree, pretty_print=False, encoding="utf-8")
 
     tstPyCSW = PyCSWDist("insert", xml_file=passFile)
     tstPyCSW._conf.mmd_xslt_path = xsltFile
-    assert type(tstPyCSW._translate()) == str
-    assert tstPyCSW._translate() == outData
+    result = tstPyCSW._translate()
+    assert isinstance(result, bytes)
+    assert result == outData
 
     caplog.clear()
     tstPyCSW = PyCSWDist("insert", xml_file=failFile)
     tstPyCSW._conf.mmd_xslt_path = xsltFile
-    assert tstPyCSW._translate() == ""
+    assert tstPyCSW._translate() == b""
     assert "Failed to translate MMD to ISO19139" in caplog.messages
 
 # END Test testDistPyCSW_Translate


### PR DESCRIPTION
**Summary**:

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.