### PR TITLE
Rewrite check_urls

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,6 +27,6 @@ jobs:
           pip install pytest-timeout
           pip install pytest-cov
       - name: Run Tests
-        run: python -m pytest -v --cov=dmci --timeout=60 -m 'not mmd_tools'
+        run: python -m pytest -v --cov=dmci --timeout=60
       - name: Upload to Codecov
         uses: codecov/codecov-action@v1

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -24,7 +24,7 @@ import logging
 from lxml import etree
 
 from dmci import CONFIG
-# from dmci.mmd_tools import full_check
+from dmci.mmd_tools import full_check
 from dmci.distributors import FileDist, PyCSWDist
 
 logger = logging.getLogger(__name__)
@@ -137,23 +137,15 @@ class Worker():
         if not valid:
             return False, "Input MMD XML file has no valid UUID metadata_identifier"
 
-        return True, "Input MMD XML file is ok"
-
-        # Commented out until mmd_tools / pythesint has been fixed
-        # When this is commented in again remember to:
-        #  - Remove "-m 'not mmd_tools'" from .github/workflows/pytest.yml
-        #  - Remove "# pragma: no cover" from dmci/mmd_tools/check_mmd.py
-        #  - Comment back in the check for the below code in test_worker.py
-
         # Check XML file
-        # logger.info("Performing in depth checking.")
-        # valid = full_check(xml_doc)
-        # if valid:
-        #     msg = "Input MMD XML file is ok"
-        # else:
-        #     msg = "Input MMD XML file contains errors, please check your file"
+        logger.info("Performing in depth checking.")
+        valid = full_check(xml_doc)
+        if valid:
+            msg = "Input MMD XML file is ok"
+        else:
+            msg = "Input MMD XML file contains errors, please check your file"
 
-        # return valid, msg
+        return valid, msg
 
     def _extract_metadata_id(self, xml_doc):
         """Extract the metadata_identifier from the xml object and set

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -119,13 +119,15 @@ def testApiWorker_CheckInfoContent(monkeypatch, filesDir):
 
     # Valid data format
     with monkeypatch.context() as mp:
-        mp.setattr("dmci.mmd_tools.check_mmd.check_urls", lambda *a, **k: True)
+        mp.setattr("dmci.mmd_tools.check_mmd.check_url", lambda *a, **k: True)
         passData = bytes(readFile(passFile), "utf-8")
-        assert tstWorker._check_information_content(passData) == (True, "Input MMD XML file is ok")
+        assert tstWorker._check_information_content(passData) == (
+            True, "Input MMD XML file is ok"
+        )
 
     # Valid data format, invalid content
     with monkeypatch.context() as mp:
-        mp.setattr("dmci.mmd_tools.check_mmd.check_urls", lambda *a, **k: False)
+        mp.setattr("dmci.mmd_tools.check_mmd.check_url", lambda *a, **k: False)
         passData = bytes(readFile(passFile), "utf-8")
         assert tstWorker._check_information_content(passData) == (
             False, "Input MMD XML file contains errors, please check your file"

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -119,18 +119,17 @@ def testApiWorker_CheckInfoContent(monkeypatch, filesDir):
 
     # Valid data format
     with monkeypatch.context() as mp:
-        mp.setattr("dmci.mmd_tools.check_mmd.check_urls", lambda *a: True)
+        mp.setattr("dmci.mmd_tools.check_mmd.check_urls", lambda *a, **k: True)
         passData = bytes(readFile(passFile), "utf-8")
         assert tstWorker._check_information_content(passData) == (True, "Input MMD XML file is ok")
 
     # Valid data format, invalid content
-    # Commented out until the checks are turned back on
-    # with monkeypatch.context() as mp:
-    #     mp.setattr("dmci.mmd_tools.check_mmd.check_urls", lambda *a: False)
-    #     passData = bytes(readFile(passFile), "utf-8")
-    #     assert tstWorker._check_information_content(passData) == (
-    #         False, "Input MMD XML file contains errors, please check your file"
-    #     )
+    with monkeypatch.context() as mp:
+        mp.setattr("dmci.mmd_tools.check_mmd.check_urls", lambda *a, **k: False)
+        passData = bytes(readFile(passFile), "utf-8")
+        assert tstWorker._check_information_content(passData) == (
+            False, "Input MMD XML file contains errors, please check your file"
+        )
 
     # Invalid XML file
     failFile = os.path.join(filesDir, "api", "failing.xml")

--- a/tests/test_mmd_tools/test_mmd_tools.py
+++ b/tests/test_mmd_tools/test_mmd_tools.py
@@ -49,7 +49,7 @@ etreeRefEmpty = etree.ElementTree(etree.XML(
 
 etreeUrlRectNok = etree.ElementTree(etree.XML(
     "<root>"
-    "  <a x='123'>https://www.met.not</a>"
+    "  <a x='123'>https://www.mæt.no</a>"
     "  <geographic_extent>"
     "    <rectangle>"
     "      <north>76.199661</north>"
@@ -119,30 +119,38 @@ def testMMDTools_CheckRectangle(caplog):
 def testMMDTools_CheckURLs(monkeypatch):
     """Test the check_urls function.
     """
-    class MockResponse:
-        def close(self):
-            pass
+    # Valid URL
+    assert check_urls(["https://www.met.no/"]) is True
 
-        def raise_for_status(self):
-            pass
+    # Schemes
+    assert check_urls(["https://www.met.no/"]) is True
+    assert check_urls(["http://www.met.no/"]) is True
+    assert check_urls(["file://www.met.no/"]) is False
+    assert check_urls(["imap://www.met.no/"]) is False
+    assert check_urls(["stuff://www.met.no/"]) is False
 
-    # Check both valid and invalid URLs
-    assert check_urls(["https://www.met.no"]) is True
-    assert check_urls(["http://met.not"]) is False
+    # Domains
+    assert check_urls(["https://www.met.no/"]) is True
+    assert check_urls(["https://met.no/"]) is True
+    assert check_urls(["https:/www.met.no/"]) is False
+    assert check_urls(["https://metno/"]) is False
 
-    with monkeypatch.context() as mp:
-        mp.setattr("requests.get", lambda *a, **k: MockResponse())
-        assert check_urls(["WMS&ploppetyboppety&GetCapabilities"]) is True
-        assert check_urls(["WMS"]) is False
+    # Path
+    assert check_urls(["https://www.met.no"], allow_no_path=True) is True
+    assert check_urls(["https://www.met.no"]) is False
+    assert check_urls(["https://www.met.no/"]) is True
+    assert check_urls(["https://www.met.no/location"]) is True
 
-    with monkeypatch.context() as mp:
-        mp.setattr("requests.head", lambda *a, **k: MockResponse())
-        assert check_urls(["dodsC/fake/url"]) is True
+    # Non-ASCII characters
+    assert check_urls(["https://www.mæt.no/"]) is False
+
+    # Unparsable
+    assert check_urls([12345]) is False
 
 # END Test testMMDTools_CheckURLs
 
 @pytest.mark.mmd_tools
-def testMMDTools_CheckCF():
+def off_testMMDTools_CheckCF():
     """Test the check_cf function.
     """
     assert check_cf(["sea_surface_temperature"]) is True
@@ -151,7 +159,7 @@ def testMMDTools_CheckCF():
 # END Test testMMDTools_CheckCF
 
 @pytest.mark.mmd_tools
-def testMMDTools_CheckVocabulary():
+def off_testMMDTools_CheckVocabulary():
     """Test the check_vocabulary function.
     """
     assert check_vocabulary(etree.ElementTree(etree.XML(
@@ -178,24 +186,24 @@ def testMMDTools_FullCheck():
     assert full_check(etreeUrlRectNok) is False
 
     # Twice the element keywords for the same vocabulary
-    root = etree.Element("toto")
-    key1 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
-    etree.SubElement(key1, "keyword").text = "air_temperature"
-    key2 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
-    etree.SubElement(key2, "keyword").text = "air_temperature"
-    assert full_check(root) is False
+    # root = etree.Element("toto")
+    # key1 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
+    # etree.SubElement(key1, "keyword").text = "air_temperature"
+    # key2 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
+    # etree.SubElement(key2, "keyword").text = "air_temperature"
+    # assert full_check(root) is False
 
     # Correct case
-    root = etree.Element("toto")
-    root1 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
-    etree.SubElement(root1, "keyword").text = "sea_surface_temperature"
-    assert full_check(root) is True
+    # root = etree.Element("toto")
+    # root1 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
+    # etree.SubElement(root1, "keyword").text = "sea_surface_temperature"
+    # assert full_check(root) is True
 
     # Two standard names provided
-    root = etree.Element("toto")
-    root1 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
-    etree.SubElement(root1, "keyword").text = "air_temperature"
-    etree.SubElement(root1, "keyword").text = "sea_surface_temperature"
-    assert full_check(root) is False
+    # root = etree.Element("toto")
+    # root1 = etree.SubElement(root, "keywords", vocabulary="Climate and Forecast Standard Names")
+    # etree.SubElement(root1, "keyword").text = "air_temperature"
+    # etree.SubElement(root1, "keyword").text = "sea_surface_temperature"
+    # assert full_check(root) is False
 
 # END Test testMMDTools_FullCheck

--- a/tests/test_mmd_tools/test_mmd_tools.py
+++ b/tests/test_mmd_tools/test_mmd_tools.py
@@ -18,58 +18,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
 import pytest
 import logging
 
 from lxml import etree
 
 from dmci.mmd_tools.check_mmd import (
-    check_rectangle, check_urls, check_cf, check_vocabulary, full_check
+    check_rectangle, check_url, check_cf, check_vocabulary, full_check
 )
-
-etreeRef = etree.ElementTree(etree.XML(
-    "<root>"
-    "  <a x='123'>https://www.met.no</a>"
-    "  <geographic_extent>"
-    "    <rectangle>"
-    "      <north>76.199661</north>"
-    "      <south>71.63427</south>"
-    "      <west>-28.114723</west>"
-    "      <east>-11.169785</east>"
-    "    </rectangle>"
-    "  </geographic_extent>"
-    "</root>"
-))
-
-etreeRefEmpty = etree.ElementTree(etree.XML(
-    "<root>"
-    "  <a x=\"123\">'xxx'/><c/><b/></a>"
-    "</root>"
-))
-
-etreeUrlRectNok = etree.ElementTree(etree.XML(
-    "<root>"
-    "  <a x='123'>https://www.mæt.no</a>"
-    "  <geographic_extent>"
-    "    <rectangle>"
-    "      <north>76.199661</north>"
-    "      <south>71.63427</south>"
-    "      <west>-28.114723</west>"
-    "    </rectangle>"
-    "  </geographic_extent>"
-    "  <keywords vocabulary='Climate and Forecast Standard Names'>"
-    "    <keyword>sea_surface_temperature</keyword>"
-    "    <keyword>air_surface_temperature</keyword>"
-    "  </keywords>"
-    "  <operational_status>NotOpen</operational_status>"
-    "</root>"
-))
 
 @pytest.mark.mmd_tools
 def testMMDTools_CheckRectangle(caplog):
     """Test the check_rectangle function.
     """
     caplog.set_level(logging.DEBUG, logger="dmci")
+    etreeRef = etree.ElementTree(etree.XML(
+        "<root>"
+        "  <resource>https://www.met.no/</resource>"
+        "  <geographic_extent>"
+        "    <rectangle>"
+        "      <north>76.199661</north>"
+        "      <south>71.63427</south>"
+        "      <west>-28.114723</west>"
+        "      <east>-11.169785</east>"
+        "    </rectangle>"
+        "  </geographic_extent>"
+        "</root>"
+    ))
 
     # Check lat/lon OK from rectangle
     rect = etreeRef.findall("./{*}geographic_extent/{*}rectangle")
@@ -116,36 +92,36 @@ def testMMDTools_CheckRectangle(caplog):
 # END Test testMMDTools_CheckRectangle
 
 @pytest.mark.mmd_tools
-def testMMDTools_CheckURLs(monkeypatch):
-    """Test the check_urls function.
+def testMMDTools_CheckURLs():
+    """Test the check_url function.
     """
     # Valid URL
-    assert check_urls(["https://www.met.no/"]) is True
+    assert check_url("https://www.met.no/") is True
 
     # Schemes
-    assert check_urls(["https://www.met.no/"]) is True
-    assert check_urls(["http://www.met.no/"]) is True
-    assert check_urls(["file://www.met.no/"]) is False
-    assert check_urls(["imap://www.met.no/"]) is False
-    assert check_urls(["stuff://www.met.no/"]) is False
+    assert check_url("https://www.met.no/") is True
+    assert check_url("http://www.met.no/") is True
+    assert check_url("file://www.met.no/") is False
+    assert check_url("imap://www.met.no/") is False
+    assert check_url("stuff://www.met.no/") is False
 
     # Domains
-    assert check_urls(["https://www.met.no/"]) is True
-    assert check_urls(["https://met.no/"]) is True
-    assert check_urls(["https:/www.met.no/"]) is False
-    assert check_urls(["https://metno/"]) is False
+    assert check_url("https://www.met.no/") is True
+    assert check_url("https://met.no/") is True
+    assert check_url("https:/www.met.no/") is False
+    assert check_url("https://metno/") is False
 
     # Path
-    assert check_urls(["https://www.met.no"], allow_no_path=True) is True
-    assert check_urls(["https://www.met.no"]) is False
-    assert check_urls(["https://www.met.no/"]) is True
-    assert check_urls(["https://www.met.no/location"]) is True
+    assert check_url("https://www.met.no", allow_no_path=True) is True
+    assert check_url("https://www.met.no") is False
+    assert check_url("https://www.met.no/") is True
+    assert check_url("https://www.met.no/location") is True
 
     # Non-ASCII characters
-    assert check_urls(["https://www.mæt.no/"]) is False
+    assert check_url("https://www.mæt.no/") is False
 
     # Unparsable
-    assert check_urls([12345]) is False
+    assert check_url(12345) is False
 
 # END Test testMMDTools_CheckURLs
 
@@ -173,17 +149,47 @@ def off_testMMDTools_CheckVocabulary():
 # END Test testMMDTools_CheckVocabulary
 
 @pytest.mark.mmd_tools
-def testMMDTools_FullCheck():
+def testMMDTools_FullCheck(filesDir, caplog):
     """Test the full_check function.
     """
+    caplog.set_level(logging.DEBUG, logger="dmci")
+    passFile = os.path.join(filesDir, "api", "passing.xml")
+    passTree = etree.parse(passFile, parser=etree.XMLParser(remove_blank_text=True))
+
     # Full check
-    assert full_check(etreeRef) is True
+    caplog.clear()
+    assert full_check(passTree) is True
+    assert "OK: 9 URLs" in caplog.text
+    assert "OK: geographic_extent/rectangle" in caplog.text
 
     # Full check with no elements to check
-    assert full_check(etreeRefEmpty) is True
+    caplog.clear()
+    assert full_check(etree.ElementTree(etree.XML("<xml />"))) is True
+    assert "Found no elements contained an URL" in caplog.text
+    assert "Found no geographic_extent/rectangle element" in caplog.text
 
     # Full check with invalid elements
+    etreeUrlRectNok = etree.ElementTree(etree.XML(
+        "<root>"
+        "  <resource>https://www.mæt.no/</resource>"
+        "  <geographic_extent>"
+        "    <rectangle>"
+        "      <north>76.199661</north>"
+        "      <south>71.63427</south>"
+        "      <west>-28.114723</west>"
+        "    </rectangle>"
+        "  </geographic_extent>"
+        "  <keywords vocabulary='Climate and Forecast Standard Names'>"
+        "    <keyword>sea_surface_temperature</keyword>"
+        "    <keyword>air_surface_temperature</keyword>"
+        "  </keywords>"
+        "  <operational_status>NotOpen</operational_status>"
+        "</root>"
+    ))
+    caplog.clear()
     assert full_check(etreeUrlRectNok) is False
+    assert "NOK: URLs" in caplog.text
+    assert "NOK: geographic_extent/rectangle" in caplog.text
 
     # Twice the element keywords for the same vocabulary
     # root = etree.Element("toto")


### PR DESCRIPTION
**Summary**:

This is a rewrite of the `check_urls` function. It now only checks that the url is ASCII, contains one of the following schemes: http, https, ftp, sftp, and checks that it has a domain with at least one dot.

The `full_check` is now enabled again, with the rectangle and url checks, and the vocabulary checks disabled for now.

**Related issue**:

Part of #49, closes #68

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.