### PR TITLE
PEP8-ify

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Syntax Error Check
         run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude external
       - name: Code Style Check
-        run: flake8 . --count --max-line-length=99 --ignore E203,E221,E226,E228,E241,E251,E261,E266,E302,E305 --show-source --statistics --exclude external
+        run: flake8 . --count --max-line-length=99 --ignore E221,E226,E228,E241 --show-source --statistics --exclude external

--- a/container/wsgi.py
+++ b/container/wsgi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : API Start Script
 =======================

--- a/dmci/__init__.py
+++ b/dmci/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Main Package Init
 ========================
@@ -18,14 +17,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+__package__ = "dmci"
+__version__ = "0.0.1"
+
 import os
 import sys
 import logging
 
 from dmci.config import Config
 
-__package__ = "dmci"
-__version__ = "0.0.1"
 
 def _init_logging(log_obj):
     """Call to initialise logging
@@ -63,6 +63,7 @@ def _init_logging(log_obj):
 
     return
 
+
 # Logging Setup
 # Must be called before the CONFIG object is created
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ _init_logging(logger)
 
 # Create config object
 CONFIG = Config()
+
 
 def api_main():
     """This is the main entry point for the api process.

--- a/dmci/api/__init__.py
+++ b/dmci/api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : API App Class
 ====================

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : API App Class
 ====================
@@ -19,10 +18,10 @@ limitations under the License.
 """
 
 import dmci
-import logging
 import os
 import sys
 import uuid
+import logging
 
 from lxml import etree
 from flask import request, Flask
@@ -30,6 +29,7 @@ from flask import request, Flask
 from dmci.api.worker import Worker
 
 logger = logging.getLogger(__name__)
+
 
 class App(Flask):
 
@@ -98,8 +98,7 @@ class App(Flask):
 
     @staticmethod
     def _persist_file(data, full_path):
-        """Write the persistent file
-        """
+        """Write the persistent file."""
         try:
             with open(full_path, "wb") as queuefile:
                 queuefile.write(data)

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Worker Class
 ===================
@@ -28,6 +27,7 @@ from dmci.tools import CheckMMD
 from dmci.distributors import FileDist, PyCSWDist
 
 logger = logging.getLogger(__name__)
+
 
 class Worker():
 
@@ -62,14 +62,14 @@ class Worker():
         """Validate the xml file against the XML style definition,
         then check the information content.
 
-        Input
-        =====
+        Parameters
+        ----------
         data : bytes
             bytes representation of the xml data
 
         Returns
-        =======
-        valid : boolean
+        -------
+        valid : bool
             True if xsd and information content checks are passing
         msg : str
             Validation message
@@ -91,6 +91,19 @@ class Worker():
     def distribute(self):
         """Loop through all distributors listed in the config and call
         them in the same order.
+
+        Returns
+        -------
+        status : bool
+            True if all distributors ran ok
+        valid : bool
+            True if all distributors are valid
+        called : list of str
+            The names of all distributors that were called (status True)
+        failed : list of str
+            The names of all distributors that failed (status False)
+        skipped : list of str
+            The names of all distributors that were skipped (invalid)
         """
         status = True
         valid  = True
@@ -128,8 +141,7 @@ class Worker():
     ##
 
     def _check_information_content(self, data):
-        """Check the information content in the submitted file
-        """
+        """Check the information content in the submitted file."""
         if not isinstance(data, bytes):
             return False, "input must be bytes type"
 

--- a/dmci/config.py
+++ b/dmci/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Main Config
 ==================
@@ -24,6 +23,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class Config():
 
     def __init__(self):
@@ -34,7 +34,7 @@ class Config():
         # Core Values
         self.call_distributors = []
         self.distributor_cache = None
-        self.max_permitted_size = 100000 # Size of files permitted through API
+        self.max_permitted_size = 100000  # Size of files permitted through API
         self.mmd_xslt_path = None
         self.mmd_xsd_path = None
 
@@ -83,8 +83,7 @@ class Config():
     ##
 
     def _read_core(self):
-        """Read config values under 'dmci'.
-        """
+        """Read config values under 'dmci'."""
         conf = self._raw_conf.get("dmci", {})
 
         self.call_distributors = conf.get("distributors", self.call_distributors)
@@ -96,8 +95,7 @@ class Config():
         return
 
     def _read_pycsw(self):
-        """Read config values under 'pycsw'.
-        """
+        """Read config values under 'pycsw'."""
         conf = self._raw_conf.get("pycsw", {})
 
         self.csw_service_url = conf.get("csw_service_url", self.csw_service_url)
@@ -105,8 +103,7 @@ class Config():
         return
 
     def _read_file(self):
-        """Read config values under 'pycsw'.
-        """
+        """Read config values under 'pycsw'."""
         conf = self._raw_conf.get("file", {})
 
         self.file_archive_path = conf.get("file_archive_path", self.file_archive_path)
@@ -114,8 +111,9 @@ class Config():
         return
 
     def _validate_config(self):
-        """Check config variable dependencies. It needs to be called after all
-        the read functions when all settings have been handled.
+        """Check config variable dependencies. It needs to be called
+        after all the read functions when all settings have been
+        handled.
         """
         valid = True
 

--- a/dmci/distributors/__init__.py
+++ b/dmci/distributors/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : File Distributor Init
 ============================

--- a/dmci/distributors/distributor.py
+++ b/dmci/distributors/distributor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Distributor Super Class
 ==============================
@@ -27,6 +26,7 @@ from dmci import CONFIG
 
 logger = logging.getLogger(__name__)
 
+
 class DistCmd(Enum):
 
     INSERT = 0
@@ -34,6 +34,7 @@ class DistCmd(Enum):
     DELETE = 2
 
 # END Enum DistCmd
+
 
 class Distributor():
 
@@ -95,12 +96,11 @@ class Distributor():
         return
 
     def run(self):
-        """The main run function to be implemented in each subclass.
-        """
+        """The main run function to be implemented in each subclass."""
         raise NotImplementedError
 
     ##
-    #  Methods
+    #  Getters
     ##
 
     def is_valid(self):

--- a/dmci/distributors/file_dist.py
+++ b/dmci/distributors/file_dist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : File Distributor
 =======================
@@ -27,6 +26,7 @@ from dmci.distributors.distributor import Distributor, DistCmd
 
 logger = logging.getLogger(__name__)
 
+
 class FileDist(Distributor):
 
     def __init__(self, cmd, xml_file=None, metadata_id=None, **kwargs):
@@ -35,8 +35,7 @@ class FileDist(Distributor):
         return
 
     def run(self):
-        """Wrapper for the various jobs, depending on command.
-        """
+        """Wrapper for the various jobs, depending on command."""
         if not self.is_valid():
             return False
 
@@ -52,9 +51,12 @@ class FileDist(Distributor):
 
         return False
 
+    ##
+    #  Internal Functions
+    ##
+
     def _add_to_archive(self):
-        """Add the xml file to the archive.
-        """
+        """Add the xml file to the archive."""
         jobsDir = self._conf.file_archive_path
         if jobsDir is None:
             logger.error("No 'file_archive_path' set")

--- a/dmci/distributors/pycsw_dist.py
+++ b/dmci/distributors/pycsw_dist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : PyCSW Distributor
 ========================
@@ -27,11 +26,12 @@ from dmci.distributors.distributor import Distributor, DistCmd
 
 logger = logging.getLogger(__name__)
 
+
 class PyCSWDist(Distributor):
 
-    TOTAL_DELETED = 'total_deleted'
-    TOTAL_INSERTED = 'total_inserted'
-    TOTAL_UPDATED = 'total_updated'
+    TOTAL_DELETED = "total_deleted"
+    TOTAL_INSERTED = "total_inserted"
+    TOTAL_UPDATED = "total_updated"
     STATUS = [TOTAL_DELETED, TOTAL_INSERTED, TOTAL_UPDATED]
 
     def __init__(self, cmd, xml_file=None, metadata_id=None, **kwargs):
@@ -58,13 +58,12 @@ class PyCSWDist(Distributor):
         elif self._cmd == DistCmd.INSERT:
             status = self._insert()
         else:
-            logger.error('Invalid command: %s' % str(self._cmd)) # pragma: no cover
+            logger.error("Invalid command: %s" % str(self._cmd))  # pragma: no cover
 
         return status
 
     def _translate(self):
-        """Convert from MMD to ISO19139, Norwegian INSPIRE profile
-        """
+        """Convert from MMD to ISO19139, Norwegian INSPIRE profile."""
         result = b""
         try:
             xml_doc = etree.ElementTree(file=self._xml_file)
@@ -78,8 +77,7 @@ class PyCSWDist(Distributor):
         return b"" if result is None else result
 
     def _insert(self):
-        """Insert in pyCSW using a Transaction
-        """
+        """Insert in pyCSW using a Transaction."""
         headers = requests.structures.CaseInsensitiveDict()
         headers["Content-Type"] = "application/xml"
         headers["Accept"] = "application/xml"
@@ -100,17 +98,16 @@ class PyCSWDist(Distributor):
         return status
 
     def _update(self):
-        """Update current entry
+        """Update current entry.
 
-        Need to find out how to do this...
+        Need to find out how to do this ...
         """
         logger.warning("Not yet implemented")
 
         return False
 
     def _delete(self):
-        """
-        """
+        """Delete from PyCSW usinf a Transaction."""
         headers = requests.structures.CaseInsensitiveDict()
         headers["Content-Type"] = "application/xml"
         headers["Accept"] = "application/xml"
@@ -141,18 +138,18 @@ class PyCSWDist(Distributor):
         return status
 
     def _get_transaction_status(self, key, resp):
-        """Check response status, read response text, and get status (boolean)
+        """Check response status, read response text, and get status.
 
-        Input
-        =====
+        Parameters
+        ----------
         key : str
             total_inserted, total_updated or total_deleted
         resp : requests.models.Response
             Response object from transaction
 
-        Return
-        ======
-        status : boolean
+        Returns
+        -------
+        status : bool
             True if the transaction succeeded, otherwise False
         """
         if key not in self.STATUS:
@@ -174,16 +171,17 @@ class PyCSWDist(Distributor):
         return status
 
     def _read_response_text(self, key, text):
-        """Read response xml text and return a dict with results
+        """Read response xml text and return a dict with results.
 
-        Input
-        =====
+        Parameters
+        ----------
         text : str
             xml representation of the pycsw result
 
-        Return
-        ======
-        dict : status of insert, update and delete
+        Returns
+        -------
+        dict
+            status of insert, update and delete
         """
         if key not in self.STATUS:
             logger.error("Input key must be '%s', '%s' or '%s'" % (
@@ -236,3 +234,5 @@ class PyCSWDist(Distributor):
             status = True
 
         return status
+
+# END Class PyCSWDist

--- a/dmci/tools/__init__.py
+++ b/dmci/tools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : MMD Tools Init
 =====================

--- a/dmci/tools/check_mmd.py
+++ b/dmci/tools/check_mmd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : MMD Checker Functions
 ============================
@@ -26,6 +25,7 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+
 class CheckMMD():
 
     def __init__(self):
@@ -35,16 +35,14 @@ class CheckMMD():
         return
 
     def clear(self):
-        """Clear the status data.
-        """
+        """Clear the status data."""
         self._status_pass = []
         self._status_fail = []
         self._status_ok = True
         return
 
     def status(self):
-        """Return the status of checks run since last clear.
-        """
+        """Return the status of checks run since last clear."""
         return self._status_ok, self._status_pass, self._status_fail
 
     def check_rectangle(self, rectangle):
@@ -53,11 +51,17 @@ class CheckMMD():
             - rectangle has north / south / west / east subelements
             - -180 <= min_lat <= max_lat <= 180
             -    0 <= min_lon <= max_lon <= 360
-        Args:
-            rectangle: list of elements found when requesting node(s)
-            geographic_extent/rectangle
-        Returns:
-            True / False
+
+        Parameters
+        ----------
+            rectangle : list of str
+                list of elements found when requesting node(s)
+                geographic_extent/rectangle
+
+        Returns
+        -------
+        bool
+            True if valid, otherwise Flase
         """
         keys = ["north", "south", "west", "east"]
         directions = dict.fromkeys(keys, None)
@@ -101,6 +105,18 @@ class CheckMMD():
 
     def check_url(self, url, allow_no_path=False):
         """Check that an URL is valid.
+
+        Parameters
+        ----------
+        url : str
+            The url to check
+        allow_no_path : bool, optional
+            If True, a url with no path set is considered valid
+
+        Returns
+        -------
+        bool
+            True if valid, otherwise False
         """
         ok = True
         err = []
@@ -134,10 +150,16 @@ class CheckMMD():
 
     def check_cf(self, xmldoc):
         """Check that names are valid CF standard names
-        Args:
-            cf_names: list of names to test
-        Returns:
-            True / False
+
+        Parameters
+        ----------
+            xmldoc : :obj:`lxml.ElementTree`
+                The XML tree to validate
+
+        Returns
+        -------
+        bool
+            True if valid, otherwise False
         """
         ok = True
         err = []
@@ -176,17 +198,24 @@ class CheckMMD():
             - activity_type
             - operational_status
             - use_constraint
-        Args:
-            xmldoc: ElementTree containing the full XML document
-        Returns:
-            True / False
-            List of errors
 
-        Comments: The following elements have test functions available
+        Note: The following elements have test functions available
         in pythesint but are not used:
         - area -> because it does not correspond to an element in
         currently tested files
         - platform type -> because erroneous thesaurus in mmd repo?
+
+        Parameters
+        ----------
+        xmldoc : :obj:`lxml.ElementTree
+            XML element containing the full XML document
+
+        Returns
+        -------
+        ok : bool
+            True if valid, otherwise False
+        err : list of str
+            List of errors
         """
         vocabularies = {
             "access_constraint":  pti.get_mmd_access_constraints,
@@ -222,16 +251,21 @@ class CheckMMD():
 
     def full_check(self, doc):
         """Main checking scripts for in depth checking of XML file.
-        - checking URLs
-        - checking lat-lon within geographic_extent/rectangle
-        - checking CF names against standard table
-        - checking controlled vocabularies (access_constraint /
-        activity_type / operational_status / use_constraint)
+            - checking URLs
+            - checking lat-lon within geographic_extent/rectangle
+            - checking CF names against standard table
+            - checking controlled vocabularies (access_constraint /
+              activity_type / operational_status / use_constraint)
 
-        Args:
-            doc: ElementTree containing the full XML document
-        Returns:
-            True / False
+        Parameters
+        ----------
+        doc : :obj:`lxml.ElementTree
+            XML element containing the full XML document
+
+        Returns
+        -------
+        bool
+            True if valid, otherwise False
         """
         self.clear()
         valid = True
@@ -266,8 +300,7 @@ class CheckMMD():
     ##
 
     def _log_result(self, check, ok, err):
-        """Write the result of a check to the status variables.
-        """
+        """Write the result of a check to the status variables."""
         if ok:
             self._status_pass.append("Passed: %s" % check)
         else:

--- a/dmci/tools/check_mmd.py
+++ b/dmci/tools/check_mmd.py
@@ -104,7 +104,7 @@ class CheckMMD():
         return ok, err
 
     def check_url(self, url, allow_no_path=False):
-        """Check that an URL is valid.
+        """Check that a URL is valid.
 
         Parameters
         ----------

--- a/dmci/tools/check_mmd.py
+++ b/dmci/tools/check_mmd.py
@@ -61,7 +61,7 @@ class CheckMMD():
         Returns
         -------
         bool
-            True if valid, otherwise Flase
+            True if valid, otherwise False
         """
         keys = ["north", "south", "west", "east"]
         directions = dict.fromkeys(keys, None)

--- a/dmci_start_api.py
+++ b/dmci_start_api.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 DMCI : API Start Script
 =======================

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,5 +46,5 @@ usr/share/doc/dmci =
 universal = 0
 
 [flake8]
-ignore = E203,E221,E226,E228,E241,E251,E261,E266,E302,E305
+ignore = E221,E226,E228,E241
 max-line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 DMCI : Package Setup
 ====================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Test Config
 ==================
@@ -26,7 +25,8 @@ import pytest
 # Note: This line forces the test suite to import the dmci package in the current source tree
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 
-from dmci.config import Config # noqa: E402
+from dmci.config import Config  # noqa: E402
+
 
 ##
 #  Directory Fixtures
@@ -37,6 +37,7 @@ def rootDir():
     """The root folder of the repository.
     """
     return os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
+
 
 @pytest.fixture(scope="session")
 def tmpDir():
@@ -53,6 +54,7 @@ def tmpDir():
         os.mkdir(theDir)
     return theDir
 
+
 @pytest.fixture(scope="session")
 def filesDir():
     """A path to the reference files folder.
@@ -60,6 +62,7 @@ def filesDir():
     testDir = os.path.dirname(__file__)
     theDir = os.path.join(testDir, "files")
     return theDir
+
 
 ##
 #  Mock Files
@@ -69,13 +72,16 @@ def filesDir():
 def mockXml(filesDir):
     return os.path.join(filesDir, "mock", "mock.xml")
 
+
 @pytest.fixture(scope="session")
 def mockXslt(filesDir):
     return os.path.join(filesDir, "mock", "mock.xslt")
 
+
 @pytest.fixture(scope="session")
 def mockXsd(filesDir):
     return os.path.join(filesDir, "mock", "mock.xsd")
+
 
 ##
 #  Objects

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -27,10 +27,10 @@ from dmci.api import App
 
 MOCK_XML = b"<xml />"
 
+
 @pytest.fixture(scope="function")
 def client(tmpDir, tmpConf, mockXsd, monkeypatch):
-    """Create an instance of the API.
-    """
+    """Create an instance of the API."""
     workDir = os.path.join(tmpDir, "api")
     if not os.path.isdir(workDir):
         os.mkdir(workDir)
@@ -46,6 +46,7 @@ def client(tmpDir, tmpConf, mockXsd, monkeypatch):
         yield client
 
     return
+
 
 @pytest.mark.api
 def testApiApp_Init(tmpConf, tmpDir, monkeypatch):
@@ -79,10 +80,10 @@ def testApiApp_Init(tmpConf, tmpDir, monkeypatch):
 
 # END Test testApiApp_Init
 
+
 @pytest.mark.api
 def testApiApp_EndPoints(client):
-    """Test requests to endpoints not in use.
-    """
+    """Test requests to endpoints not in use."""
     assert client.get("/").status_code == 404
     assert client.get("/v1/").status_code == 404
 
@@ -98,10 +99,10 @@ def testApiApp_EndPoints(client):
 
 # END Test testApiApp_EndPoints
 
+
 @pytest.mark.api
-def testApiApp_InsertRequests(client, filesDir, monkeypatch):
-    """Test api insert requests.
-    """
+def testApiApp_InsertRequests(client, monkeypatch):
+    """Test api insert requests."""
     assert isinstance(client, flask.testing.FlaskClient)
 
     # Test sending 3MB of data
@@ -138,10 +139,10 @@ def testApiApp_InsertRequests(client, filesDir, monkeypatch):
 
 # END Test testApiApp_InsertRequests
 
+
 @pytest.mark.api
 def testApiApp_PersistFile(tmpDir, monkeypatch):
-    """Test the persistent file writer function.
-    """
+    """Test the persistent file writer function."""
     assert App._persist_file(MOCK_XML, None)[1] == 507
 
     outFile = os.path.join(tmpDir, "app_persist_file.xml")

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Worker Class Test
 ========================
@@ -28,19 +27,19 @@ from dmci.api.worker import Worker
 from dmci.distributors import FileDist, PyCSWDist
 from dmci.tools import CheckMMD
 
+
 @pytest.mark.api
 def testApiWorker_Init():
-    """Test the Worker class init.
-    """
+    """Test the Worker class init."""
     assert Worker(None, None)._dist_cmd == "insert"
     assert Worker(None, None, a=1)._kwargs == {"a": 1}
 
 # END Test testApiWorker_Init
 
+
 @pytest.mark.api
-def testApiWorker_Distributor(tmpDir, tmpConf, mockXml, monkeypatch):
-    """Test the Worker class distributor.
-    """
+def testApiWorker_Distributor(tmpConf, mockXml, monkeypatch):
+    """Test the Worker class distributor."""
     tmpConf.call_distributors = ["file", "pycsw", "blabla"]
 
     # Call the distributor function with the distributors from the config
@@ -82,18 +81,18 @@ def testApiWorker_Distributor(tmpDir, tmpConf, mockXml, monkeypatch):
     tstWorker._dist_xml_file = "/path/to/nowhere"
 
     status, valid, called, failed, skipped = tstWorker.distribute()
-    assert status is True # No jobs were run since all were skipped
-    assert valid is False # All jobs were invalid due to the command
+    assert status is True  # No jobs were run since all were skipped
+    assert valid is False  # All jobs were invalid due to the command
     assert called == []
     assert failed == []
     assert skipped == ["file", "pycsw", "blabla"]
 
 # END Test testApiWorker_Distributor
 
+
 @pytest.mark.api
 def testApiWorker_Validator(monkeypatch, filesDir):
-    """Test the Worker class validator.
-    """
+    """Test the Worker class validator."""
     xsdFile = os.path.join(filesDir, "mmd", "mmd.xsd")
     passFile = os.path.join(filesDir, "api", "passing.xml")
     failFile = os.path.join(filesDir, "api", "failing.xml")
@@ -126,10 +125,10 @@ def testApiWorker_Validator(monkeypatch, filesDir):
 
 # END Test testApiWorker_Validator
 
+
 @pytest.mark.api
 def testApiWorker_CheckInfoContent(monkeypatch, filesDir):
-    """Test _check_information_content
-    """
+    """Test _check_information_content."""
     passFile = os.path.join(filesDir, "api", "passing.xml")
     tstWorker = Worker(passFile, None)
 
@@ -188,10 +187,10 @@ def testApiWorker_CheckInfoContent(monkeypatch, filesDir):
 
 # END Test testApiWorker_CheckInfoContent
 
+
 @pytest.mark.api
 def testApiWorker_ExtractMetaDataID(filesDir, mockXml):
-    """Test _check_information_content
-    """
+    """Test _check_information_content."""
     passFile = os.path.join(filesDir, "api", "passing.xml")
     failFile = os.path.join(filesDir, "api", "failing.xml")
 

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Config Class Test
 ========================
@@ -25,10 +24,10 @@ from tools import causeOSError
 
 from dmci.config import Config
 
+
 @pytest.mark.core
 def testCoreConfig_ReadFile(filesDir, monkeypatch):
-    """Test reading config file.
-    """
+    """Test reading config file."""
     theConf = Config()
 
     # Read some values and see that we get them
@@ -61,10 +60,10 @@ def testCoreConfig_ReadFile(filesDir, monkeypatch):
 
 # END Test testCoreConfig_ReadFile
 
+
 @pytest.mark.core
 def testCoreConfig_Validate(rootDir, filesDir, tmpDir):
-    """Test that the class reads all settings and validates them.
-    """
+    """Test that the class reads all settings and validates them."""
     exampleConf = os.path.join(rootDir, "example_config.yaml")
     theConf = Config()
 

--- a/tests/test_core/test_init.py
+++ b/tests/test_core/test_init.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Package Init Test
 ========================
@@ -28,19 +27,19 @@ from tools import readFile
 
 from dmci.config import Config
 
+
 @pytest.mark.core
 def testCoreInit_Init():
-    """Test the package initialisation.
-    """
+    """Test the package initialisation."""
     assert dmci.__version__
     assert isinstance(dmci.CONFIG, dmci.config.Config)
 
 # END Test testCoreInit_Init
 
+
 @pytest.mark.core
 def testCoreInit_Logger(tmpDir):
-    """Test the logger initialisation.
-    """
+    """Test the logger initialisation."""
     os.environ["DMCI_LOGLEVEL"] = "DEBUG"
     logger = logging.getLogger(__name__)
     dmci._init_logging(logger)
@@ -66,10 +65,10 @@ def testCoreInit_Logger(tmpDir):
 
 # END Test testCoreInit_Logger
 
+
 @pytest.mark.core
 def testCoreInit_ApiMain(monkeypatch, rootDir):
-    """Test the API entry point function
-    """
+    """Test the API entry point function."""
     class mockAPI():
         def __init__(self):
             pass

--- a/tests/test_dist/test_distributor.py
+++ b/tests/test_dist/test_distributor.py
@@ -59,7 +59,7 @@ def testDistDistributor_Init(mockXml):
 @pytest.mark.dist
 def testDistDistributor_Run():
     """Test the Distributor super class run function.
- 
+
     Calling run() on the superclass should raise an error as this
     function must be implemented in subclasses.
     """

--- a/tests/test_dist/test_distributor.py
+++ b/tests/test_dist/test_distributor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Distributor Class Test
 =============================
@@ -22,10 +21,10 @@ import pytest
 
 from dmci.distributors.distributor import Distributor
 
+
 @pytest.mark.dist
-def testDistDistributor_Init(tmpDir, mockXml):
-    """Test the Distributor super class init.
-    """
+def testDistDistributor_Init(mockXml):
+    """Test the Distributor super class init."""
     # Check Insert Command
     assert Distributor("insert", metadata_id="some_id").is_valid() is False
     assert Distributor("insert", xml_file="/path/to/nowhere").is_valid() is False
@@ -56,9 +55,11 @@ def testDistDistributor_Init(tmpDir, mockXml):
 
 # END Test testDistDistributor_Init
 
+
 @pytest.mark.dist
-def testDistDistributor_Run(tmpDir):
+def testDistDistributor_Run():
     """Test the Distributor super class run function.
+ 
     Calling run() on the superclass should raise an error as this
     function must be implemented in subclasses.
     """

--- a/tests/test_dist/test_file_dist.py
+++ b/tests/test_dist/test_file_dist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : File Distributor Class Test
 ==================================
@@ -28,10 +27,10 @@ from dmci.api.worker import Worker
 from dmci.distributors import FileDist
 from dmci.distributors.distributor import DistCmd
 
+
 @pytest.mark.dist
 def testDistFile_Init():
-    """Test the FileDist class init.
-    """
+    """Test the FileDist class init."""
     # Check that it initialises properly by running some of the simple
     # Distributor class tests
     assert FileDist("insert", metadata_id="some_id").is_valid() is False
@@ -41,10 +40,10 @@ def testDistFile_Init():
 
 # END Test testDistFile_Init
 
+
 @pytest.mark.dist
-def testDistFile_Run(tmpDir, mockXml):
-    """Test the FileDist class run function.
-    """
+def testDistFile_Run(mockXml):
+    """Test the FileDist class run function."""
     tstDist = FileDist("insert", xml_file=mockXml)
     assert tstDist.is_valid()
 
@@ -68,10 +67,10 @@ def testDistFile_Run(tmpDir, mockXml):
 
 # END Test testDistFile_Run
 
+
 @pytest.mark.dist
 def testDistFile_InsertUpdate(tmpDir, filesDir, monkeypatch):
-    """Test the FileDist class insert and update actions.
-    """
+    """Test the FileDist class insert and update actions."""
     fileDir = os.path.join(tmpDir, "file")
     archDir = os.path.join(fileDir, "archive")
     passFile = os.path.join(filesDir, "api", "passing.xml")

--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : PyCSW Distributor Class Test
 ===================================
@@ -26,10 +25,10 @@ from lxml import etree
 
 from dmci.distributors.pycsw_dist import PyCSWDist
 
+
 @pytest.mark.dist
 def testDistPyCSW_Init():
-    """Test the PyCSWDist class init.
-    """
+    """Test the PyCSWDist class init."""
     # Check that it initialises properly by running some of the simple
     # Distributor class tests
     assert PyCSWDist("insert", metadata_id="some_id").is_valid() is False
@@ -39,18 +38,20 @@ def testDistPyCSW_Init():
 
 # END Test testDistPyCSW_Init
 
+
 @pytest.mark.dist
 def testDistPyCSW_Run():
+    """Test the run command with invalid parameters."""
     # WRONG command test
     assert PyCSWDist("blabla", metadata_id="some_id").run() is False
     assert PyCSWDist("insert", metadata_id="some_id").run() is False
 
 # END Test testDistPyCSW_Run
 
+
 @pytest.mark.dist
 def testDistPyCSW_Insert(monkeypatch, mockXml, mockXslt):
-    """Test insert commands via run()
-    """
+    """Test insert commands via run()"""
     # insert returns True
     with monkeypatch.context() as mp:
         mp.setattr(PyCSWDist, "_translate", lambda *a: b"<xml />")
@@ -75,19 +76,19 @@ def testDistPyCSW_Insert(monkeypatch, mockXml, mockXslt):
 
 # END Test testDistPyCSW_Insert
 
+
 @pytest.mark.dist
 def testDistPyCSW_Update(mockXml):
-    """Test update commands via run()
-    """
+    """Test update commands via run()"""
     assert PyCSWDist("update", xml_file=mockXml).run() is False
     assert PyCSWDist("update", metadata_id="some_id").run() is False
 
 # END Test testDistPyCSW_Update
 
+
 @pytest.mark.dist
 def testDistPyCSW_Delete(monkeypatch, mockXml):
-    """Test delete commands via run()
-    """
+    """Test delete commands via run()"""
     assert PyCSWDist("delete").run() is False
     assert PyCSWDist("delete", xml_file=mockXml).run() is False
 
@@ -109,10 +110,10 @@ def testDistPyCSW_Delete(monkeypatch, mockXml):
 
 # END Test testDistPyCSW_Delete
 
+
 @pytest.mark.dist
 def testDistPyCSW_Translate(filesDir, caplog):
-    """_translate tests
-    """
+    """_translate tests"""
     passFile = os.path.join(filesDir, "api", "passing.xml")
     failFile = os.path.join(filesDir, "not_an_xml_file.xml")
     xsltFile = os.path.join(filesDir, "mmd", "mmd-to-geonorge.xslt")
@@ -135,10 +136,10 @@ def testDistPyCSW_Translate(filesDir, caplog):
 
 # END Test testDistPyCSW_Translate
 
+
 @pytest.mark.dist
 def testDistPyCSW_GetTransactionStatus(monkeypatch, mockXml):
-    """_get_transaction_status tests
-    """
+    """_get_transaction_status tests"""
     # wrong key
     resp = requests.models.Response()
     assert PyCSWDist("insert", xml_file=mockXml)._get_transaction_status("tull", resp) is False
@@ -185,10 +186,10 @@ def testDistPyCSW_GetTransactionStatus(monkeypatch, mockXml):
 
 # END Test testDistPyCSW_GetTransactionStatus
 
+
 @pytest.mark.dist
 def testDistPyCSW_ReadResponse(mockXml, caplog):
-    """_read_response_text tests
-    """
+    """_read_response_text tests"""
     # text wrongkey
     assert PyCSWDist("insert", xml_file=mockXml)._read_response_text("tull", "some text") is False
 

--- a/tests/test_mmd_tools/test_mmd_tools.py
+++ b/tests/test_mmd_tools/test_mmd_tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : MMD Tools Module Tests
 =============================
@@ -25,10 +24,10 @@ from lxml import etree
 
 from dmci.tools import CheckMMD
 
+
 @pytest.mark.tools
 def testMMDTools_CheckRectangle():
-    """Test the check_rectangle function.
-    """
+    """Test the check_rectangle function."""
     chkMMD = CheckMMD()
 
     # Check lat/lon OK from rectangle
@@ -170,10 +169,10 @@ def testMMDTools_CheckRectangle():
 
 # END Test testMMDTools_CheckRectangle
 
+
 @pytest.mark.tools
 def testMMDTools_CheckURLs():
-    """Test the check_url function.
-    """
+    """Test the check_url function."""
     chkMMD = CheckMMD()
 
     # Valid URL
@@ -248,10 +247,10 @@ def testMMDTools_CheckURLs():
 
 # END Test testMMDTools_CheckURLs
 
+
 @pytest.mark.tools
 def testMMDTools_CheckCF():
-    """Test the check_cf function.
-    """
+    """Test the check_cf function."""
     chkMMD = CheckMMD()
 
     ok, err, n = chkMMD.check_cf(etree.ElementTree(etree.XML(
@@ -304,10 +303,10 @@ def testMMDTools_CheckCF():
 
 # END Test testMMDTools_CheckCF
 
+
 @pytest.mark.tools
 def testMMDTools_CheckVocabulary():
-    """Test the check_vocabulary function.
-    """
+    """Test the check_vocabulary function."""
     chkMMD = CheckMMD()
     ok, err = chkMMD.check_vocabulary(etree.ElementTree(etree.XML(
         "<root><operational_status>Operational</operational_status></root>"
@@ -323,10 +322,10 @@ def testMMDTools_CheckVocabulary():
 
 # END Test testMMDTools_CheckVocabulary
 
+
 @pytest.mark.tools
 def testMMDTools_FullCheck(filesDir):
-    """Test the full_check function.
-    """
+    """Test the full_check function."""
     chkMMD = CheckMMD()
     passFile = os.path.join(filesDir, "api", "passing.xml")
     passTree = etree.parse(passFile, parser=etree.XMLParser(remove_blank_text=True))

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DMCI : Test Tools
 =================
@@ -18,19 +17,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+
 # File I/O
 
 def readFile(fileName):
-    """Returns the content of a file as a string.
-    """
+    """Returns the content of a file as a string."""
     with open(fileName, mode="r", encoding="utf8") as inFile:
         return inFile.read()
 
+
 def writeFile(fileName, fileData):
-    """Write the contents of a string to a file.
-    """
+    """Write the contents of a string to a file."""
     with open(fileName, mode="w", encoding="utf8") as outFile:
         outFile.write(fileData)
+
 
 # Exceptions
 


### PR DESCRIPTION
**Summary**:

Turn back on a bunch of flake8 tests to increase PEP8 compliance, and make at least the docstrings with full description numpy compliant (they were mixed formats).

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.