### PR TITLE
Issue #57: Implement update and delete in file_dist

### DIFF
--- a/dmci/distributors/file_dist.py
+++ b/dmci/distributors/file_dist.py
@@ -80,27 +80,32 @@ class FileDist(Distributor):
         archPath = os.path.join(self._conf.file_archive_path, lvlA, lvlB, lvlC)
         archFile = os.path.join(archPath, fileName)
 
-        status = "added"
         if os.path.isfile(archFile):
             if self._cmd == DistCmd.UPDATE:
                 status = "replaced"
-            else:
-                logger.error("File already exists: %s" % archFile)
-                return False, "Failed to archive file: %s" % fileName
+            else:  # INSERT
+                logger.error("File already exists: %s", archFile)
+                return False, "File already exists: %s" % fileName
+        else:
+            if self._cmd == DistCmd.INSERT:
+                status = "added"
+            else:  # UPDATE
+                logger.error("Cannot update non-existing file: %s", archFile)
+                return False, "Cannot update non-existing file: %s" % fileName
 
         try:
             os.makedirs(archPath, exist_ok=True)
-            logger.info("Created folder: %s" % archPath)
+            logger.info("Created folder: %s", archPath)
         except Exception as e:
-            logger.error("Could not make folder(s): %s" % archPath)
+            logger.error("Could not make folder(s): %s", archPath)
             logger.error(str(e))
             return False, "Failed to archive file: %s" % fileName
 
         try:
             shutil.copy2(self._xml_file, archFile)
         except Exception as e:
-            logger.error("Failed to archive file src: %s" % self._xml_file)
-            logger.error("Failed to archive file dst: %s" % archFile)
+            logger.error("Failed to archive file src: %s", self._xml_file)
+            logger.error("Failed to archive file dst: %s", archFile)
             logger.error(str(e))
             return False, "Failed to archive file: %s" % fileName
 

--- a/tests/test_dist/test_file_dist.py
+++ b/tests/test_dist/test_file_dist.py
@@ -114,7 +114,14 @@ def testDistFile_InsertUpdate(tmpDir, filesDir, monkeypatch):
             False, "Failed to archive file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
         )
 
-    # Finally, test a successful write
+    # Update a new file is not allowed
+    tstDist._cmd = DistCmd.UPDATE
+    assert tstDist.run() == (
+        False, "Cannot update non-existing file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
+    )
+
+    # Insert a new file is allowed
+    tstDist._cmd = DistCmd.INSERT
     assert tstDist.run() == (
         True, "Added file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
     )
@@ -131,12 +138,12 @@ def testDistFile_InsertUpdate(tmpDir, filesDir, monkeypatch):
     archFile = os.path.join(dirC, "a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml")
     assert os.path.isfile(archFile)
 
-    # Should not be allowed to write the same file twice
+    # Insert and existing file is not allowed
     assert tstDist.run() == (
-        False, "Failed to archive file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
+        False, "File already exists: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
     )
 
-    # Unless command is to update
+    # Update an existing file is allowed
     tstDist._cmd = DistCmd.UPDATE
     assert tstDist.run() == (
         True, "Replaced file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"

--- a/tests/test_dist/test_file_dist.py
+++ b/tests/test_dist/test_file_dist.py
@@ -52,6 +52,7 @@ def testDistFile_Run(mockXml):
     tstDist._valid = True
 
     tstDist._add_to_archive = lambda *a: (True, "test")
+    tstDist._delete_from_archive = lambda *a: (True, "test")
 
     tstDist._cmd = DistCmd.INSERT
     assert tstDist.run() == (True, "test")
@@ -60,7 +61,7 @@ def testDistFile_Run(mockXml):
     assert tstDist.run() == (True, "test")
 
     tstDist._cmd = DistCmd.DELETE
-    assert tstDist.run() == (False, "The `delete' command is not implemented")
+    assert tstDist.run() == (True, "test")
 
     tstDist._cmd = 1234
     assert tstDist.run() == (False, "No job was run")
@@ -71,7 +72,7 @@ def testDistFile_Run(mockXml):
 @pytest.mark.dist
 def testDistFile_InsertUpdate(tmpDir, filesDir, monkeypatch):
     """Test the FileDist class insert and update actions."""
-    fileDir = os.path.join(tmpDir, "file")
+    fileDir = os.path.join(tmpDir, "file_insupd")
     archDir = os.path.join(fileDir, "archive")
     passFile = os.path.join(filesDir, "api", "passing.xml")
 
@@ -150,3 +151,55 @@ def testDistFile_InsertUpdate(tmpDir, filesDir, monkeypatch):
     )
 
 # END Test testDistFile_InsertUpdate
+
+
+@pytest.mark.dist
+def testDistFile_Delete(tmpDir, filesDir, monkeypatch):
+    """Test the FileDist class insert and update actions."""
+    fileDir = os.path.join(tmpDir, "file_delete")
+    archDir = os.path.join(fileDir, "archive")
+    passFile = os.path.join(filesDir, "api", "passing.xml")
+
+    # Set up a Worker object
+    passXML = lxml.etree.fromstring(bytes(readFile(passFile), "utf-8"))
+    tstWorker = Worker(passFile, None)
+    assert tstWorker._extract_metadata_id(passXML) is True
+    assert tstWorker._file_metadata_id is not None
+
+    tstDist = FileDist("insert", xml_file=passFile)
+    tstDist._conf.file_archive_path = archDir
+    tstDist._worker = tstWorker
+
+    # Insert a new file to delete
+    tstDist._cmd = DistCmd.INSERT
+    assert tstDist.run() == (
+        True, "Added file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
+    )
+
+    # Try to delete with no identifier set
+    tstDist._cmd = DistCmd.DELETE
+    goodUUID = tstWorker._file_metadata_id
+    tstWorker._file_metadata_id = "123456789abcdefghijkl"
+    assert tstDist.run() == (
+        False, "No valid metadata_identifier provided, cannot delete file"
+    )
+
+    # Set the identifier and try to delete again, but fail on unlink
+    tstWorker._file_metadata_id = goodUUID
+    with monkeypatch.context() as mp:
+        mp.setattr("os.unlink", causeOSError)
+        assert tstDist.run() == (
+            False, "Failed to delete file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
+        )
+
+    # Delete properly
+    assert tstDist.run() == (
+        True, "Deleted file: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
+    )
+
+    # Delete again should fail as the file no longer exists
+    assert tstDist.run() == (
+        False, "File not found: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
+    )
+
+# END Test testDistFile_Delete

--- a/tests/test_dist/test_file_dist.py
+++ b/tests/test_dist/test_file_dist.py
@@ -139,7 +139,7 @@ def testDistFile_InsertUpdate(tmpDir, filesDir, monkeypatch):
     archFile = os.path.join(dirC, "a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml")
     assert os.path.isfile(archFile)
 
-    # Insert and existing file is not allowed
+    # Insert an existing file is not allowed
     assert tstDist.run() == (
         False, "File already exists: a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b.xml"
     )


### PR DESCRIPTION
**Summary**:

This PR adds the code for the delete command in file_dist, and changes the insert/update command to fail when the user tries to insert when a file exists, or update when a file does not exist. These serve as a low level safe guard for an erroneous call to the API.

**Related issue**:

Colses #57

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [x] The headers of all files contain a reference to the repository license
* [x] 100% test coverage of new code - meaning:
  * [x] The overall test coverage increased or remained the same as before
  * [x] Every function is accompanied with a test suite
  * [x] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [x] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [x] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.