### PR TITLE
#79: added a function to return the ok-string to avoid repetition, an…

### DIFF
--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -70,13 +70,16 @@ class App(Flask):
             if err:
                 return "\n".join(err), 500
             else:
-                return "Everything is OK", 200
+                return self._everything_is_ok()
 
         return
 
     ##
     #  Internal Functions
     ##
+
+    def _everything_is_ok(self):
+        return "Everything is OK\n", 200
 
     def _insert_update_method_post(self, cmd, request):
         """Process insert or update command requests."""
@@ -109,7 +112,7 @@ class App(Flask):
             return msg, 500
         else:
             self._handle_persist_file(True, full_path)
-            return "Everything is OK", 200
+            return self._everything_is_ok()
 
     def _distributor_wrapper(self, worker):
         """Run the distributors and handle and parse the results and

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -186,7 +186,7 @@ def testApiApp_DeleteRequests(client, monkeypatch):
         mp.setattr("dmci.api.app.Worker.distribute", lambda *a: (True, True, [], [], [], []))
         response = client.post("/v1/delete/%s" % testUUID, data=MOCK_XML)
         assert response.status_code == 200
-        assert response.data == b"Everything is OK"
+        assert response.data == b"Everything is OK\n"
 
 # END Test testApiApp_DeleteRequests
 


### PR DESCRIPTION
…d added escape character

**Summary**: closes #79 

**Related issue**: #79 

**Suggested reviewer(s)**: @vkbo 

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.