### PR TITLE
Issue #79: API return message line endings

### DIFF
--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -140,7 +140,7 @@ def testApiApp_InsertUpdateRequests(client, monkeypatch):
             b"The following distributors failed: A, B\n"
             b" - A: Reason A\n"
             b" - B: Reason B\n"
-            b"The following jobs were skipped: C"
+            b"The following jobs were skipped: C\n"
         )
 
         response = client.post("/v1/update", data=MOCK_XML)
@@ -149,7 +149,7 @@ def testApiApp_InsertUpdateRequests(client, monkeypatch):
             b"The following distributors failed: A, B\n"
             b" - A: Reason A\n"
             b" - B: Reason B\n"
-            b"The following jobs were skipped: C"
+            b"The following jobs were skipped: C\n"
         )
 
 # END Test testApiApp_InsertRequests
@@ -178,7 +178,7 @@ def testApiApp_DeleteRequests(client, monkeypatch):
             b"The following distributors failed: A, B\n"
             b" - A: Reason A\n"
             b" - B: Reason B\n"
-            b"The following jobs were skipped: C"
+            b"The following jobs were skipped: C\n"
         )
 
     # Distribute ok
@@ -186,7 +186,7 @@ def testApiApp_DeleteRequests(client, monkeypatch):
         mp.setattr("dmci.api.app.Worker.distribute", lambda *a: (True, True, [], [], [], []))
         response = client.post("/v1/delete/%s" % testUUID, data=MOCK_XML)
         assert response.status_code == 200
-        assert response.data == b"Everything is OK"
+        assert response.data == b"Everything is OK\n"
 
 # END Test testApiApp_DeleteRequests
 


### PR DESCRIPTION
**Summary**:

This PR correctly fixes the line endings problem for API return messages.

**Related issue**:

Closes #79, replaces PR #81

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.