### PR TITLE
Issue #78: Add validator command to API

### DIFF
--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -78,6 +78,7 @@ class App(Flask):
 
         @self.route("/v1/validate", methods=["POST"])
         def post_validate():
+            """Process validate command."""
             msg, code = self._validate_method_post(request)
             return self._formatMsgReturn(msg), code
 

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -76,6 +76,11 @@ class App(Flask):
             else:
                 return self._formatMsgReturn(OK_RETURN), 200
 
+        @self.route("/v1/validate", methods=["POST"])
+        def post_validate():
+            msg, code = self._validate_method_post(request)
+            return self._formatMsgReturn(msg), code
+
         return
 
     ##
@@ -96,7 +101,7 @@ class App(Flask):
     def _insert_update_method_post(self, cmd, request):
         """Process insert or update command requests."""
         if request.content_length > self._conf.max_permitted_size:
-            return f"File bigger than permitted size: {self._conf.max_permitted_size}", 413
+            return f"The file is larger than maximum size: {self._conf.max_permitted_size}", 413
 
         data = request.get_data()
 
@@ -125,6 +130,30 @@ class App(Flask):
         else:
             self._handle_persist_file(True, full_path)
             return OK_RETURN, 200
+
+    def _validate_method_post(self, request):
+        """Only run the validator for submitted file."""
+        if request.content_length > self._conf.max_permitted_size:
+            return f"The file is larger than maximum size: {self._conf.max_permitted_size}", 413
+
+        data = request.get_data()
+
+        # Cache the job file
+        file_uuid = uuid.uuid4()
+        full_path = os.path.join(self._conf.distributor_cache, f"{file_uuid}.xml")
+        msg, code = self._persist_file(data, full_path)
+        if code != 200:
+            os.unlink(full_path)
+            return msg, code
+
+        # Run the validator
+        worker = Worker("none", full_path, self._xsd_obj)
+        valid, msg = worker.validate(data)
+        os.unlink(full_path)
+        if valid:
+            return OK_RETURN, 200
+        else:
+            return msg, 400
 
     def _distributor_wrapper(self, worker):
         """Run the distributors and handle and parse the results and

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -143,13 +143,13 @@ class App(Flask):
         full_path = os.path.join(self._conf.distributor_cache, f"{file_uuid}.xml")
         msg, code = self._persist_file(data, full_path)
         if code != 200:
-            os.unlink(full_path)
+            self._handle_persist_file(True, full_path)
             return msg, code
 
         # Run the validator
         worker = Worker("none", full_path, self._xsd_obj)
         valid, msg = worker.validate(data)
-        os.unlink(full_path)
+        self._handle_persist_file(True, full_path)
         if valid:
             return OK_RETURN, 200
         else:

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -78,7 +78,7 @@ class Worker():
         # Takes in bytes-object data
         # Gives msg when both validating and not validating
         if not isinstance(data, bytes):
-            return False, "input must be bytes type"
+            return False, "Input must be bytes type"
 
         # Check xml file against XML schema definition
         valid = self._xsd_obj.validate(etree.fromstring(data))
@@ -148,7 +148,7 @@ class Worker():
     def _check_information_content(self, data):
         """Check the information content in the submitted file."""
         if not isinstance(data, bytes):
-            return False, "input must be bytes type"
+            return False, "Input must be bytes type"
 
         # Read XML file
         xml_doc = etree.fromstring(data)

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -105,8 +105,8 @@ def testApiWorker_Validator(monkeypatch, filesDir):
     failFile = os.path.join(filesDir, "api", "failing.xml")
 
     xsdObj = lxml.etree.XMLSchema(lxml.etree.parse(xsdFile))
-    passWorker = Worker("insert", passFile, xsdObj)
-    failWorker = Worker("insert", failFile, xsdObj)
+    passWorker = Worker("none", passFile, xsdObj)
+    failWorker = Worker("none", failFile, xsdObj)
 
     # Invalid data format
     passData = readFile(passFile)
@@ -137,7 +137,7 @@ def testApiWorker_Validator(monkeypatch, filesDir):
 def testApiWorker_CheckInfoContent(monkeypatch, filesDir):
     """Test _check_information_content."""
     passFile = os.path.join(filesDir, "api", "passing.xml")
-    tstWorker = Worker("insert", passFile, None)
+    tstWorker = Worker("none", passFile, None)
 
     # Invalid data format
     passData = readFile(passFile)

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -110,7 +110,7 @@ def testApiWorker_Validator(monkeypatch, filesDir):
 
     # Invalid data format
     passData = readFile(passFile)
-    assert passWorker.validate(passData) == (False, "input must be bytes type")
+    assert passWorker.validate(passData) == (False, "Input must be bytes type")
 
     # Valid data format
     with monkeypatch.context() as mp:
@@ -141,7 +141,7 @@ def testApiWorker_CheckInfoContent(monkeypatch, filesDir):
 
     # Invalid data format
     passData = readFile(passFile)
-    assert tstWorker._check_information_content(passData) == (False, "input must be bytes type")
+    assert tstWorker._check_information_content(passData) == (False, "Input must be bytes type")
 
     # Valid data format
     with monkeypatch.context() as mp:


### PR DESCRIPTION
**Summary**:

This PR adds a `/vi/validate` endpoint to the API that will validate a single file without calling any distributors.

**Related issue**:

Closes #78

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [x] The headers of all files contain a reference to the repository license
* [x] 100% test coverage of new code - meaning:
  * [x] The overall test coverage increased or remained the same as before
  * [x] Every function is accompanied with a test suite
  * [x] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [x] Functions with optional arguments have separate tests for all options
* [x] Examples are supported by doctests
* [x] All tests are passing
* [x] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.