### PR TITLE
Issue87 file archive delete fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ python dmci_start_api.py
 Then you can post with curl to the api - endpoint:
 
 ```bash
-curl --data-binary "@<PATH_TO_MMD_FILE>" localhost:5000/v1/insert
+curl --data-binary "@<PATH_TO_MMD_FILE>" localhost:5000/v1/validate
 ```
-insert is currently the only implemented command. Other commands will return 404 Not Found until implementation.
+Available commands are: validate, insert or create, update, and delete.
 
 The API uses HTTP return codes, and expected returns are:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ curl --data-binary "@<PATH_TO_MMD_FILE>" localhost:5000/v1/validate
 curl -X POST localhost:5000/v1/delete/<UUID_OF_FILE_TO_DELETE>
 
 ```
-Available commands are: validate, insert or create, update, and delete.
+Available commands are: validate, insert or create, update, and delete. Note that insert and create is the same - insert will be removed in the next major version (1.0).
 
 The API uses HTTP return codes, and expected returns are:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ python dmci_start_api.py
 Then you can post with curl to the api - endpoint:
 
 ```bash
+# Validate, insert, create and update call signature
 curl --data-binary "@<PATH_TO_MMD_FILE>" localhost:5000/v1/validate
+# Delete works differently
+curl -X POST localhost:5000/v1/delete/<UUID_OF_FILE_TO_DELETE>
+
 ```
 Available commands are: validate, insert or create, update, and delete.
 

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -56,6 +56,7 @@ class App(Flask):
             sys.exit(1)
 
         # Set up api entry points
+        @self.route("/v1/create", methods=["POST"])
         @self.route("/v1/insert", methods=["POST"])
         def post_insert():
             msg, code = self._insert_update_method_post("insert", request)

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -123,7 +123,7 @@ class Worker():
                 self._dist_cmd,
                 xml_file=self._dist_xml_file,
                 metadata_id=self._dist_metadata_id,
-                worker=self,
+                worker=self
             )
             valid &= obj.is_valid()
             if obj.is_valid():

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -119,13 +119,11 @@ class Worker():
             if dist not in self.CALL_MAP:
                 skipped.append(dist)
                 continue
-
             obj = self.CALL_MAP[dist](
                 self._dist_cmd,
                 xml_file=self._dist_xml_file,
                 metadata_id=self._dist_metadata_id,
                 worker=self,
-                **self._kwargs
             )
             valid &= obj.is_valid()
             if obj.is_valid():

--- a/dmci/distributors/distributor.py
+++ b/dmci/distributors/distributor.py
@@ -18,6 +18,7 @@ limitations under the License.
 """
 
 import os
+import uuid
 import logging
 
 from enum import Enum
@@ -69,11 +70,11 @@ class Distributor():
                     return
 
             if metadata_id is not None:
-                if isinstance(metadata_id, str) and metadata_id:
+                if isinstance(metadata_id, uuid.UUID) and metadata_id:
                     self._metadata_id = metadata_id
                     self._valid = True
                 else:
-                    logger.error("Metadata identifier must be a non-empty string")
+                    logger.error("Metadata identifier must be a valid UUID")
                     self._valid = False
                     return
 

--- a/dmci/distributors/file_dist.py
+++ b/dmci/distributors/file_dist.py
@@ -110,7 +110,7 @@ class FileDist(Distributor):
 
     def _delete_from_archive(self):
         """Delete a file from the archive."""
-        fileUUID = self._worker._file_metadata_id
+        fileUUID = self._metadata_id
         if not isinstance(fileUUID, uuid.UUID):
             msg = "No valid metadata_identifier provided, cannot delete file"
             logger.error(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ limitations under the License.
 
 import os
 import sys
+import uuid
 import shutil
 import pytest
 
@@ -104,3 +105,8 @@ def tmpConf(monkeypatch):
     theConf.readConfig(confFile)
     monkeypatch.setattr("dmci.CONFIG", theConf)
     return theConf
+
+
+@pytest.fixture(scope="function")
+def tmpUUID():
+    return uuid.uuid4()

--- a/tests/test_dist/test_distributor.py
+++ b/tests/test_dist/test_distributor.py
@@ -23,17 +23,18 @@ from dmci.distributors.distributor import Distributor
 
 
 @pytest.mark.dist
-def testDistDistributor_Init(mockXml):
+def testDistDistributor_Init(mockXml, tmpUUID):
     """Test the Distributor super class init."""
+
     # Check Insert Command
-    assert Distributor("insert", metadata_id="some_id").is_valid() is False
+    assert Distributor("insert", metadata_id=tmpUUID).is_valid() is False
     assert Distributor("insert", xml_file="/path/to/nowhere").is_valid() is False
     assert Distributor("insert", xml_file=mockXml).is_valid() is True
     assert Distributor("inSeRt", xml_file=mockXml).is_valid() is True
     assert Distributor("insert", xml_file=mockXml, metadata_id="stuff").is_valid() is False
 
     # Check Update Command
-    assert Distributor("update", metadata_id="some_id").is_valid() is False
+    assert Distributor("update", metadata_id=tmpUUID).is_valid() is False
     assert Distributor("update", xml_file="/path/to/nowhere").is_valid() is False
     assert Distributor("update", xml_file=mockXml).is_valid() is True
     assert Distributor("uPdatE", xml_file=mockXml).is_valid() is True
@@ -43,27 +44,27 @@ def testDistDistributor_Init(mockXml):
     assert Distributor("delete", xml_file=mockXml).is_valid() is False
     assert Distributor("delete", metadata_id=None).is_valid() is False
     assert Distributor("delete", metadata_id=1234).is_valid() is False
-    assert Distributor("delete", metadata_id="some_id").is_valid() is True
-    assert Distributor("deLEte", metadata_id="some_id").is_valid() is True
-    assert Distributor("delete", xml_file=mockXml, metadata_id="some_id").is_valid() is False
+    assert Distributor("delete", metadata_id=tmpUUID).is_valid() is True
+    assert Distributor("deLEte", metadata_id=tmpUUID).is_valid() is True
+    assert Distributor("delete", xml_file=mockXml, metadata_id=tmpUUID).is_valid() is False
 
     # Check Unsupported Command
-    assert Distributor("blabla", metadata_id="some_id").is_valid() is False
+    assert Distributor("blabla", metadata_id=tmpUUID).is_valid() is False
     assert Distributor("blabla", xml_file=mockXml).is_valid() is False
-    assert Distributor(12345678, metadata_id="some_id").is_valid() is False
+    assert Distributor(12345678, metadata_id=tmpUUID).is_valid() is False
     assert Distributor(12345678, xml_file=mockXml).is_valid() is False
 
 # END Test testDistDistributor_Init
 
 
 @pytest.mark.dist
-def testDistDistributor_Run():
+def testDistDistributor_Run(tmpUUID):
     """Test the Distributor super class run function.
 
     Calling run() on the superclass should raise an error as this
     function must be implemented in subclasses.
     """
     with pytest.raises(NotImplementedError):
-        Distributor("insert", metadata_id="some_id").run()
+        Distributor("insert", metadata_id=tmpUUID).run()
 
 # END Test testDistDistributor_Run

--- a/tests/test_dist/test_file_dist.py
+++ b/tests/test_dist/test_file_dist.py
@@ -29,14 +29,14 @@ from dmci.distributors.distributor import DistCmd
 
 
 @pytest.mark.dist
-def testDistFile_Init():
+def testDistFile_Init(tmpUUID):
     """Test the FileDist class init."""
     # Check that it initialises properly by running some of the simple
     # Distributor class tests
-    assert FileDist("insert", metadata_id="some_id").is_valid() is False
-    assert FileDist("update", metadata_id="some_id").is_valid() is False
-    assert FileDist("delete", metadata_id="some_id").is_valid() is True
-    assert FileDist("blabla", metadata_id="some_id").is_valid() is False
+    assert FileDist("insert", metadata_id=tmpUUID).is_valid() is False
+    assert FileDist("update", metadata_id=tmpUUID).is_valid() is False
+    assert FileDist("delete", metadata_id=tmpUUID).is_valid() is True
+    assert FileDist("blabla", metadata_id=tmpUUID).is_valid() is False
 
 # END Test testDistFile_Init
 
@@ -179,13 +179,14 @@ def testDistFile_Delete(tmpDir, filesDir, monkeypatch):
     # Try to delete with no identifier set
     tstDist._cmd = DistCmd.DELETE
     goodUUID = tstWorker._file_metadata_id
-    tstWorker._file_metadata_id = "123456789abcdefghijkl"
+
+    tstWorker._metadata_id  = "123456789abcdefghijkl"
     assert tstDist.run() == (
         False, "No valid metadata_identifier provided, cannot delete file"
     )
 
     # Set the identifier and try to delete again, but fail on unlink
-    tstWorker._file_metadata_id = goodUUID
+    tstDist._metadata_id = goodUUID
     with monkeypatch.context() as mp:
         mp.setattr("os.unlink", causeOSError)
         assert tstDist.run() == (

--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -28,24 +28,24 @@ from dmci.distributors.pycsw_dist import PyCSWDist
 
 
 @pytest.mark.dist
-def testDistPyCSW_Init():
+def testDistPyCSW_Init(tmpUUID):
     """Test the PyCSWDist class init."""
     # Check that it initialises properly by running some of the simple
     # Distributor class tests
-    assert PyCSWDist("insert", metadata_id="some_id").is_valid() is False
-    assert PyCSWDist("update", metadata_id="some_id").is_valid() is False
-    assert PyCSWDist("delete", metadata_id="some_id").is_valid() is True
-    assert PyCSWDist("blabla", metadata_id="some_id").is_valid() is False
+    assert PyCSWDist("insert", metadata_id=tmpUUID).is_valid() is False
+    assert PyCSWDist("update", metadata_id=tmpUUID).is_valid() is False
+    assert PyCSWDist("delete", metadata_id=tmpUUID).is_valid() is True
+    assert PyCSWDist("blabla", metadata_id=tmpUUID).is_valid() is False
 
 # END Test testDistPyCSW_Init
 
 
 @pytest.mark.dist
-def testDistPyCSW_Run():
+def testDistPyCSW_Run(tmpUUID):
     """Test the run command with invalid parameters."""
     # WRONG command test
-    assert PyCSWDist("blabla", metadata_id="some_id").run() == (False, "The run job is invalid")
-    assert PyCSWDist("insert", metadata_id="some_id").run() == (False, "The run job is invalid")
+    assert PyCSWDist("blabla", metadata_id=tmpUUID).run() == (False, "The run job is invalid")
+    assert PyCSWDist("insert", metadata_id=tmpUUID).run() == (False, "The run job is invalid")
 
 # END Test testDistPyCSW_Run
 
@@ -120,7 +120,7 @@ def testDistPyCSW_Update(monkeypatch, mockXml, mockXslt):
 
 
 @pytest.mark.dist
-def testDistPyCSW_Delete(monkeypatch, mockXml):
+def testDistPyCSW_Delete(monkeypatch, mockXml, tmpUUID):
     """Test delete commands via run()."""
     class mockResp:
         text = "Mock response"
@@ -135,7 +135,7 @@ def testDistPyCSW_Delete(monkeypatch, mockXml):
             "dmci.distributors.pycsw_dist.requests.post", lambda *a, **k: mockResp
         )
         mp.setattr(PyCSWDist, "_get_transaction_status", lambda *a: True)
-        assert PyCSWDist("delete", metadata_id="some_id").run() == (True, "Mock response")
+        assert PyCSWDist("delete", metadata_id=tmpUUID).run() == (True, "Mock response")
 
     # delete returns false
     with monkeypatch.context() as mp:
@@ -143,7 +143,7 @@ def testDistPyCSW_Delete(monkeypatch, mockXml):
             "dmci.distributors.pycsw_dist.requests.post", lambda *a, **k: mockResp
         )
         mp.setattr(PyCSWDist, "_get_transaction_status", lambda *a: False)
-        assert PyCSWDist("delete", metadata_id="some_id").run() == (False, "Mock response")
+        assert PyCSWDist("delete", metadata_id=tmpUUID).run() == (False, "Mock response")
 
 # END Test testDistPyCSW_Delete
 


### PR DESCRIPTION
**Summary**:

- Adds alias for insert command: create
- Updates readme to add this
- Fixes an issue with keyword argument dictionary being unpacked causing multiple instances of some keywords
- Delete_from_archive in file_distributor does not use uninstanced _file_metadata_id
- Enforce metadata_id to be of type UUID 

**Related issue**:

Closes #87 
Partly? Closes #88 

**Suggested reviewer(s)**:

@mortenwh 

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.