### PR TITLE
Check if mmd v3.3 can be imported

### DIFF
--- a/tests/files/mmd/mmd.xsd
+++ b/tests/files/mmd/mmd.xsd
@@ -2,7 +2,7 @@
 <xs:schema elementFormDefault="qualified" targetNamespace="http://www.met.no/schema/mmd"
            xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace"
            xmlns:mmd="http://www.met.no/schema/mmd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xs:import schemaLocation="xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xs:import schemaLocation="http://www.w3.org/2001/xml.xsd" namespace="http://www.w3.org/XML/1998/namespace"/>
     <xs:element name="mmd" type="mmd:mmd_type"></xs:element>
     <xs:complexType name="personnel_type">
         <xs:all>
@@ -39,13 +39,13 @@
             </xs:element>
             <xs:element name="collection" type="mmd:collection_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
             <xs:element name="last_metadata_update" type="mmd:last_metadata_update_type" maxOccurs="1" minOccurs="1"></xs:element>
-            <xs:element name="temporal_extent" type="mmd:temporal_extent_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
+            <xs:element name="temporal_extent" type="mmd:temporal_extent_type" maxOccurs="1" minOccurs="0"></xs:element>
             <xs:element name="iso_topic_category" type="mmd:iso_topic_category_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
             <xs:element name="keywords" type="mmd:keywords_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
             <xs:choice maxOccurs="unbounded">
                 <xs:element name="operational_status" type="mmd:operational_status_type" minOccurs="0" maxOccurs="1"></xs:element>
                 <xs:element name="dataset_language" type="xs:string" maxOccurs="1" minOccurs="0" default="en"></xs:element>
-                <xs:element name="geographic_extent" type="mmd:geographic_extent_type" maxOccurs="1" minOccurs="1"></xs:element>
+                <xs:element name="geographic_extent" type="mmd:geographic_extent_type" maxOccurs="1" minOccurs="0"></xs:element>
                 <xs:element name="access_constraint" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
                 <xs:element name="use_constraint" type="mmd:use_constraint_type" maxOccurs="1" minOccurs="0"></xs:element>
                 <xs:element name="project" type="mmd:project_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
@@ -54,11 +54,17 @@
                 <xs:element name="instrument" type="mmd:instrument_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
                 -->
                 <xs:element name="platform" type="mmd:platform_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
+                <xs:element name="spatial_representation" type="mmd:spatial_representation" maxOccurs="1" minOccurs="0"></xs:element>
                 <xs:element name="related_information" type="mmd:related_information_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
-                <xs:element name="personnel" type="mmd:personnel_type" maxOccurs="unbounded" minOccurs="1"></xs:element>
+                <xs:element name="personnel" type="mmd:personnel_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
                 <xs:element name="dataset_citation" type="mmd:dataset_citation_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
+                <xs:element name="quality_control" type="xs:string" maxOccurs="1" minOccurs="0"></xs:element>
                 <xs:element name="data_access" type="mmd:data_access_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
-                <xs:element name="data_center" type="mmd:data_center_type" maxOccurs="unbounded" minOccurs="0"></xs:element>
+                <xs:element name="data_center" type="mmd:data_center_type" maxOccurs="1" minOccurs="0"></xs:element>
+                <xs:element name="system_specific_product_category" type="mmd:system_specific_product_category_type"
+                            maxOccurs="unbounded"/>
+                <xs:element name="system_specific_product_relevance" type="mmd:system_specific_product_relevance_type"
+                            maxOccurs="unbounded"/>
                 <xs:element name="related_dataset" type="mmd:related_dataset_type" maxOccurs="unbounded" minOccurs="0"/>
                 <xs:element name="storage_information" type="mmd:storage_information_type" maxOccurs="1" minOccurs="0" />
             </xs:choice>
@@ -81,6 +87,7 @@
             <xs:enumeration value="Created"></xs:enumeration>
             <xs:enumeration value="Minor modification"></xs:enumeration>
             <xs:enumeration value="Major modification"></xs:enumeration>
+            <xs:enumeration value="Original record"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="temporal_extent_type">
@@ -138,6 +145,11 @@
         <xs:sequence>
             <xs:element name="identifier" type="mmd:use_constraint_identifier_type" maxOccurs="1" minOccurs="0"></xs:element>
             <xs:element name="resource" type="mmd:use_constraint_resource_type" maxOccurs="1" minOccurs="0"></xs:element>
+            <xs:element name="license_text" type="xs:string" maxOccurs="1" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>This element holds the a free-text non formal license. If used identifier and resource should be left empty.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
     </xs:complexType>
     <xs:simpleType name="use_constraint_identifier_type">
@@ -154,19 +166,12 @@
     <xs:simpleType name="use_constraint_resource_type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="http://spdx.org/licenses/CC0-1.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC0-1.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-4.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC-BY-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-SA-4.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC-BY-SA-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-NC-4.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC-BY-NC-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-NC-SA-4.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC-BY-NC-SA-4.0"></xs:enumeration>
             <xs:enumeration value="http://spdx.org/licenses/CC-BY-ND-4.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC-BY-ND-4.0"></xs:enumeration>
-            <xs:enumeration value="http://spdx.org/licenses/CC-BY-NC-ND-4.0"></xs:enumeration>
-            <xs:enumeration value="https://spdx.org/licenses/CC-BY-NC-ND-4.0"></xs:enumeration>
+            <xs:enumeration value="http://spdx.org/licenses/CC-BY-NC-ND-4.0"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="instrument_type">
@@ -202,6 +207,8 @@
             <xs:enumeration value="SLC"></xs:enumeration>
             <xs:enumeration value="GRD"></xs:enumeration>
             <xs:enumeration value="OCN"></xs:enumeration>
+            <xs:enumeration value="S2MSI1C"></xs:enumeration>
+            <xs:enumeration value="S2MSI2A"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="role_type">
@@ -218,6 +225,7 @@
             <xs:enumeration value="In Work"></xs:enumeration>
             <xs:enumeration value="Complete"></xs:enumeration>
             <xs:enumeration value="Obsolete"></xs:enumeration>
+            <xs:enumeration value="Not available"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="iso_topic_category_type">
@@ -241,6 +249,7 @@
             <xs:enumeration value="structure"></xs:enumeration>
             <xs:enumeration value="transportation"></xs:enumeration>
             <xs:enumeration value="utilitiesCommunications"></xs:enumeration>
+            <xs:enumeration value="Not available"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="platform_type">
@@ -273,6 +282,14 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="NRT"></xs:enumeration>
             <xs:enumeration value="NTC"></xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="spatial_representation">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="grid"></xs:enumeration>
+            <xs:enumeration value="vector"></xs:enumeration>
+            <xs:enumeration value="point"></xs:enumeration>
+            <xs:enumeration value="trajectory"></xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="keywords_type">
@@ -338,6 +355,18 @@
             <xs:element name="long_name" type="xs:string"></xs:element>
         </xs:sequence>
     </xs:complexType>
+    <xsd:complexType name="system_specific_product_relevance_type">
+        <xsd:sequence>
+            <xsd:element name="used_by" type="mmd:used_by_type" maxOccurs="unbounded"/>
+            <xsd:element name="relevance" type="xsd:string" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="system_specific_product_category_type">
+        <xsd:sequence>
+            <xsd:element name="used_by" type="mmd:used_by_type" maxOccurs="unbounded"/>
+            <xsd:element name="category" type="xsd:string" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
     <xsd:complexType name="used_by_type">
         <xsd:attribute name="for" type="xsd:string"/>
     </xsd:complexType>
@@ -361,6 +390,7 @@
             <xs:enumeration value="Pre-Operational"></xs:enumeration>
             <xs:enumeration value="Experimental"></xs:enumeration>
             <xs:enumeration value="Scientific"/>
+            <xs:enumeration value="Not available"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:complexType name="related_information_type">

--- a/tests/files/reference/pycsw_dist_translated.xml
+++ b/tests/files/reference/pycsw_dist_translated.xml
@@ -1,137 +1,121 @@
-<gmi:MI_Metadata xmlns:gmi="http://www.isotc211.org/2005/gmi">
-  <gmd:fileIdentifier xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b</gco:CharacterString>
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gco="http://www.isotc211.org/2005/gco" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/iso/19139/20060504/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://schemas.opengis.net/iso/19139/20060504/gmx/gmx.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b</gco:CharacterString>
   </gmd:fileIdentifier>
-  <gmd:language xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:language>
     <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2" codeListValue="eng">English</gmd:LanguageCode>
   </gmd:language>
-  <gmd:locale xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <gmd:PT_Locale id="locale-nob">
-      <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2" codeListValue="nob">Norwegian</gmd:LanguageCode>
-      </gmd:languageCode>
-      <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="resources/Codelist/gmxcodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
-      </gmd:characterEncoding>
-    </gmd:PT_Locale>
-  </gmd:locale>
-  <gmd:hierarchyLevel xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
-  </gmd:hierarchyLevel>
-  <gmd:characterSet xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:characterSet>
     <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode"/>
   </gmd:characterSet>
-  <gmd:contact xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:parentIdentifier>
+    <gco:CharacterString>64db6102-14ce-41e9-b93b-61dbb2cb8b4e</gco:CharacterString>
+  </gmd:parentIdentifier>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
+  </gmd:hierarchyLevel>
+  <gmd:contact>
     <gmd:CI_ResponsibleParty>
       <gmd:organisationName>
-        <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">unknown</gco:CharacterString>
+        <gco:CharacterString>unknown</gco:CharacterString>
       </gmd:organisationName>
       <gmd:contactInfo>
         <gmd:CI_Contact>
           <gmd:address>
             <gmd:CI_Address>
               <gmd:electronicMailAddress>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">post@met.no</gco:CharacterString>
+                <gco:CharacterString>post@met.no</gco:CharacterString>
               </gmd:electronicMailAddress>
             </gmd:CI_Address>
           </gmd:address>
         </gmd:CI_Contact>
       </gmd:contactInfo>
       <gmd:role>
-        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="owner">owner</gmd:CI_RoleCode>
+        <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
       </gmd:role>
     </gmd:CI_ResponsibleParty>
   </gmd:contact>
-  <gmd:dateStamp xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2021-04-29</gco:Date>
+  <gmd:dateStamp>
+    <gco:Date>2021-04-29</gco:Date>
   </gmd:dateStamp>
-  <gmd:metadataStandardName xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">ISO 19115:2003/19139</gco:CharacterString>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
   </gmd:metadataStandardName>
-  <gmd:metadataStandardVersion xmlns:gmd="http://www.isotc211.org/2005/gmd">
-    <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">1.0</gco:CharacterString>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>1.0</gco:CharacterString>
   </gmd:metadataStandardVersion>
-  <gmd:referenceSystemInfo xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:locale>
+    <gmd:PT_Locale id="locale-nor">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2" codeListValue="nor">Norwegian</gmd:LanguageCode>
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="resources/Codelist/gmxcodelists.xml#MD_CharacterSetCode" codeListValue="utf8"/>
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:referenceSystemInfo>
     <gmd:MD_ReferenceSystem>
       <gmd:referenceSystemIdentifier>
         <gmd:RS_Identifier>
           <gmd:code>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">EPSG:4326</gco:CharacterString>
+            <gco:CharacterString>EPSG:4326</gco:CharacterString>
           </gmd:code>
         </gmd:RS_Identifier>
       </gmd:referenceSystemIdentifier>
     </gmd:MD_ReferenceSystem>
   </gmd:referenceSystemInfo>
-  <gmd:identificationInfo xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:identificationInfo>
     <gmd:MD_DataIdentification>
       <gmd:citation>
         <gmd:CI_Citation>
-          <gmd:title xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="PT_FreeText_PropertyType">
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Direct Broadcast data processed in satellite swath to L1C</gco:CharacterString>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Direct Broadcast data processed in satellite swath to L1C</gco:CharacterString>
             <gmd:PT_FreeText>
               <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#locale-nob"/>
+                <gmd:LocalisedCharacterString locale="#locale-nor"/>
               </gmd:textGroup>
             </gmd:PT_FreeText>
           </gmd:title>
           <gmd:date>
             <gmd:CI_Date>
               <gmd:date>
-                <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2021-04-29</gco:Date>
+                <gco:Date>2021-04-29</gco:Date>
               </gmd:date>
               <gmd:dateType>
                 <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
-          <gmd:date>
-            <gmd:CI_Date>
-              <gmd:date>
-                <gco:DateTime xmlns:gco="http://www.isotc211.org/2005/gco">2021-04-29T00:46:05Z</gco:DateTime>
-              </gmd:date>
-              <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
-              </gmd:dateType>
-            </gmd:CI_Date>
-          </gmd:date>
-          <gmd:date>
-            <gmd:CI_Date>
-              <gmd:date>
-                <gco:DateTime xmlns:gco="http://www.isotc211.org/2005/gco">2021-04-29T00:46:05Z</gco:DateTime>
-              </gmd:date>
-              <gmd:dateType>
-                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
-              </gmd:dateType>
-            </gmd:CI_Date>
-          </gmd:date>
           <gmd:identifier>
             <gmd:MD_Identifier>
               <gmd:code>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b</gco:CharacterString>
+                <gco:CharacterString>a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b</gco:CharacterString>
               </gmd:code>
             </gmd:MD_Identifier>
           </gmd:identifier>
         </gmd:CI_Citation>
       </gmd:citation>
-      <gmd:abstract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="PT_FreeText_PropertyType">
-        <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Direct Broadcast data received at MET NORWAY Oslo. Processed by standard processing software to geolocated and calibrated values in satellite swath in received instrument resolution.</gco:CharacterString>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Direct Broadcast data received at MET NORWAY Oslo. Processed by standard processing software to geolocated and calibrated values in satellite swath in received instrument resolution.</gco:CharacterString>
         <gmd:PT_FreeText>
           <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#locale-nob"/>
+            <gmd:LocalisedCharacterString locale="#locale-nor"/>
           </gmd:textGroup>
         </gmd:PT_FreeText>
       </gmd:abstract>
       <gmd:pointOfContact>
         <gmd:CI_ResponsibleParty>
           <gmd:organisationName>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">MET NORWAY</gco:CharacterString>
+            <gco:CharacterString>MET NORWAY</gco:CharacterString>
           </gmd:organisationName>
           <gmd:contactInfo>
             <gmd:CI_Contact>
               <gmd:address>
                 <gmd:CI_Address>
                   <gmd:electronicMailAddress>
-                    <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">post@met.no</gco:CharacterString>
+                    <gco:CharacterString>post@met.no</gco:CharacterString>
                   </gmd:electronicMailAddress>
                 </gmd:CI_Address>
               </gmd:address>
@@ -145,17 +129,37 @@
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
           <gmd:keyword>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Earth Science &gt; Atmosphere &gt; Atmospheric radiation</gco:CharacterString>
+            <gco:CharacterString>Earth Science &gt; Atmosphere &gt; Atmospheric radiation</gco:CharacterString>
           </gmd:keyword>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
               <gmd:title>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">NASA/GCMD Earth Science Keywords</gco:CharacterString>
+                <gco:CharacterString>GCMD</gco:CharacterString>
+              </gmd:title>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword>
+            <gco:CharacterString>Meteorological geographical features</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>Atmospheric conditions</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:keyword>
+            <gco:CharacterString>Oceanographic geographical features</gco:CharacterString>
+          </gmd:keyword>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme">GEMET - INSPIRE themes, version 1.0</gmx:Anchor>
               </gmd:title>
               <gmd:date>
                 <gmd:CI_Date>
                   <gmd:date>
-                    <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2021-02-12</gco:Date>
+                    <gco:Date>2008-06-01</gco:Date>
                   </gmd:date>
                   <gmd:dateType>
                     <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
@@ -169,53 +173,13 @@
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
           <gmd:keyword>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Meteorological geographical features</gco:CharacterString>
-          </gmd:keyword>
-          <gmd:keyword>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Atmospheric conditions</gco:CharacterString>
-          </gmd:keyword>
-          <gmd:keyword>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Oceanographic geographical features</gco:CharacterString>
+            <gco:CharacterString>Weather and climate</gco:CharacterString>
           </gmd:keyword>
           <gmd:thesaurusName>
             <gmd:CI_Citation>
               <gmd:title>
-                <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://inspire.ec.europa.eu/theme">GEMET - INSPIRE themes, version 1.0</gmx:Anchor>
+                <gco:CharacterString>Norwegian thematic categories</gco:CharacterString>
               </gmd:title>
-              <gmd:date>
-                <gmd:CI_Date>
-                  <gmd:date>
-                    <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2008-06-01</gco:Date>
-                  </gmd:date>
-                  <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
-                  </gmd:dateType>
-                </gmd:CI_Date>
-              </gmd:date>
-            </gmd:CI_Citation>
-          </gmd:thesaurusName>
-        </gmd:MD_Keywords>
-      </gmd:descriptiveKeywords>
-      <gmd:descriptiveKeywords>
-        <gmd:MD_Keywords>
-          <gmd:keyword>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Weather and climate</gco:CharacterString>
-          </gmd:keyword>
-          <gmd:thesaurusName>
-            <gmd:CI_Citation>
-              <gmd:title>
-                <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://register.geonorge.no/subregister/metadata-kodelister/kartverket/nasjonal-temainndeling">Norwegian thematic categories</gmx:Anchor>
-              </gmd:title>
-              <gmd:date>
-                <gmd:CI_Date>
-                  <gmd:date>
-                    <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2014-10-28</gco:Date>
-                  </gmd:date>
-                  <gmd:dateType>
-                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
-                  </gmd:dateType>
-                </gmd:CI_Date>
-              </gmd:date>
             </gmd:CI_Citation>
           </gmd:thesaurusName>
         </gmd:MD_Keywords>
@@ -226,7 +190,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
           </gmd:accessConstraints>
           <gmd:otherConstraints>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">conditionsUnknown</gco:CharacterString>
+            <gco:CharacterString>conditionsUnknown</gco:CharacterString>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
@@ -236,7 +200,7 @@
             <gmd:MD_RestrictionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions">otherRestrictions</gmd:MD_RestrictionCode>
           </gmd:useConstraints>
           <gmd:otherConstraints>
-            <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://spdx.org/licenses/CC-BY-4.0">Creative Commons BY 4.0 (CC BY 4.0)</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://spdx.org/licenses/CC-BY-4.0">Creative Commons BY 4.0 (CC BY 4.0)</gmx:Anchor>
           </gmd:otherConstraints>
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
@@ -260,23 +224,23 @@
           <gmd:geographicElement>
             <gmd:EX_GeographicBoundingBox>
               <gmd:westBoundLongitude>
-                <gco:Decimal xmlns:gco="http://www.isotc211.org/2005/gco">1.5549301</gco:Decimal>
+                <gco:Decimal>1.5549301</gco:Decimal>
               </gmd:westBoundLongitude>
               <gmd:eastBoundLongitude>
-                <gco:Decimal xmlns:gco="http://www.isotc211.org/2005/gco">79.40124</gco:Decimal>
+                <gco:Decimal>79.40124</gco:Decimal>
               </gmd:eastBoundLongitude>
               <gmd:southBoundLatitude>
-                <gco:Decimal xmlns:gco="http://www.isotc211.org/2005/gco">36.540688</gco:Decimal>
+                <gco:Decimal>36.540688</gco:Decimal>
               </gmd:southBoundLatitude>
               <gmd:northBoundLatitude>
-                <gco:Decimal xmlns:gco="http://www.isotc211.org/2005/gco">80.49233</gco:Decimal>
+                <gco:Decimal>80.49233</gco:Decimal>
               </gmd:northBoundLatitude>
             </gmd:EX_GeographicBoundingBox>
           </gmd:geographicElement>
           <gmd:temporalElement>
             <gmd:EX_TemporalExtent>
               <gmd:extent>
-                <gml:TimePeriod xmlns:gml="http://www.opengis.net/gml" gml:id="Temporal">
+                <gml:TimePeriod gml:id="Temporal">
                   <gml:beginPosition>2021-04-29T00:28:44.977627Z</gml:beginPosition>
                   <gml:endPosition>2021-04-29T00:39:55.000000Z</gml:endPosition>
                 </gml:TimePeriod>
@@ -287,46 +251,14 @@
       </gmd:extent>
     </gmd:MD_DataIdentification>
   </gmd:identificationInfo>
-  <gmi:acquisitionInformation>
-    <gmi:MI_AcquisitionInformation>
-      <gmi:platform>
-        <gmi:MI_Platform>
-          <gmi:identifier>
-            <gmd:MD_Identifier xmlns:gmd="http://www.isotc211.org/2005/gmd">
-              <gmd:code>
-                <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.wmo-sat.info/oscar/satellites/view/aqua">Aqua</gmx:Anchor>
-              </gmd:code>
-            </gmd:MD_Identifier>
-          </gmi:identifier>
-          <gmi:description>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Aqua</gco:CharacterString>
-          </gmi:description>
-          <gmi:instrument>
-            <gmi:MI_Instrument>
-              <gmi:identifier>
-                <gmd:MD_Identifier xmlns:gmd="http://www.isotc211.org/2005/gmd">
-                  <gmd:code>
-                    <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://www.wmo-sat.info/oscar/instruments/view/modis">MODIS</gmx:Anchor>
-                  </gmd:code>
-                </gmd:MD_Identifier>
-              </gmi:identifier>
-              <gmi:type>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">MODIS</gco:CharacterString>
-              </gmi:type>
-            </gmi:MI_Instrument>
-          </gmi:instrument>
-        </gmi:MI_Platform>
-      </gmi:platform>
-    </gmi:MI_AcquisitionInformation>
-  </gmi:acquisitionInformation>
-  <gmd:distributionInfo xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:distributionInfo>
     <gmd:MD_Distribution>
       <gmd:distributionFormat>
         <gmd:MD_Format>
           <gmd:name>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">NetCDF-CF</gco:CharacterString>
+            <gco:CharacterString>NetCDF-CF</gco:CharacterString>
           </gmd:name>
-          <gmd:version xmlns:gco="http://www.isotc211.org/2005/gco" gco:nilReason="unknown"/>
+          <gmd:version gco:nilReason="unknown"/>
         </gmd:MD_Format>
       </gmd:distributionFormat>
       <gmd:transferOptions>
@@ -337,13 +269,13 @@
                 <gmd:URL>https://thredds.met.no/thredds/dodsC/remotesensingsatellite/polar-swath/2021/04/29/aqua-modis-1km-20210429002844-20210429003955.nc</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">OPENDAP:OPENDAP</gco:CharacterString>
+                <gco:CharacterString>OPENDAP:OPENDAP</gco:CharacterString>
               </gmd:protocol>
               <gmd:name>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco"/>
+                <gco:CharacterString/>
               </gmd:name>
               <gmd:description>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Open-source Project for a Network Data Access Protocol</gco:CharacterString>
+                <gco:CharacterString>Open-source Project for a Network Data Access Protocol</gco:CharacterString>
               </gmd:description>
               <gmd:function>
                 <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
@@ -356,13 +288,13 @@
                 <gmd:URL>https://thredds.met.no/thredds/wms/remotesensingsatellite/polar-swath/2021/04/29/aqua-modis-1km-20210429002844-20210429003955.nc?service=WMS&amp;version=1.3.0&amp;request=GetCapabilities?SERVICE=WMS&amp;REQUEST=GetCapabilities</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">OGC:WMS</gco:CharacterString>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
               </gmd:protocol>
               <gmd:name>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco"/>
+                <gco:CharacterString/>
               </gmd:name>
               <gmd:description>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">OGC Web Mapping Service, URI to GetCapabilities Document.</gco:CharacterString>
+                <gco:CharacterString>OGC Web Mapping Service, URI to GetCapabilities Document.</gco:CharacterString>
               </gmd:description>
               <gmd:function>
                 <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
@@ -375,13 +307,13 @@
                 <gmd:URL>https://thredds.met.no/thredds/fileServer/remotesensingsatellite/polar-swath/2021/04/29/aqua-modis-1km-20210429002844-20210429003955.nc</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">download</gco:CharacterString>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
               </gmd:protocol>
               <gmd:name>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco"/>
+                <gco:CharacterString/>
               </gmd:name>
               <gmd:description>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">Direct download of file</gco:CharacterString>
+                <gco:CharacterString>Direct download of file</gco:CharacterString>
               </gmd:description>
               <gmd:function>
                 <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
@@ -392,12 +324,12 @@
       </gmd:transferOptions>
     </gmd:MD_Distribution>
   </gmd:distributionInfo>
-  <gmd:dataQualityInfo xmlns:gmd="http://www.isotc211.org/2005/gmd">
+  <gmd:dataQualityInfo>
     <gmd:DQ_DataQuality>
       <gmd:scope>
         <gmd:DQ_Scope>
           <gmd:level>
-            <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode"/>
+            <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/gmxCodelists.xml#MD_ScopeCode">dataset</gmd:MD_ScopeCode>
           </gmd:level>
         </gmd:DQ_Scope>
       </gmd:scope>
@@ -408,12 +340,12 @@
               <gmd:specification>
                 <gmd:CI_Citation>
                   <gmd:title>
-                    <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</gco:CharacterString>
+                    <gco:CharacterString>COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</gco:CharacterString>
                   </gmd:title>
                   <gmd:date>
                     <gmd:CI_Date>
                       <gmd:date>
-                        <gco:Date xmlns:gco="http://www.isotc211.org/2005/gco">2010-12-08</gco:Date>
+                        <gco:Date>2010-12-08</gco:Date>
                       </gmd:date>
                       <gmd:dateType>
                         <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
@@ -423,9 +355,9 @@
                 </gmd:CI_Citation>
               </gmd:specification>
               <gmd:explanation>
-                <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">The dataset has not been evaluated against the requirements of Inspire</gco:CharacterString>
+                <gco:CharacterString>The dataset has not been evaluated against the requirements of Inspire</gco:CharacterString>
               </gmd:explanation>
-              <gmd:pass xmlns:gco="http://www.isotc211.org/2005/gco" gco:nilReason="unknown"/>
+              <gmd:pass gco:nilReason="unknown"/>
             </gmd:DQ_ConformanceResult>
           </gmd:result>
         </gmd:DQ_DomainConsistency>
@@ -433,10 +365,10 @@
       <gmd:lineage>
         <gmd:LI_Lineage>
           <gmd:statement>
-            <gco:CharacterString xmlns:gco="http://www.isotc211.org/2005/gco">No lineage statement has been provided</gco:CharacterString>
+            <gco:CharacterString>No lineage statement has been provided</gco:CharacterString>
           </gmd:statement>
         </gmd:LI_Lineage>
       </gmd:lineage>
     </gmd:DQ_DataQuality>
   </gmd:dataQualityInfo>
-</gmi:MI_Metadata>
+</gmd:MD_Metadata>


### PR DESCRIPTION
**Summary**:

Updates MMD-files used in testing to MMD [v3.3](https://github.com/metno/mmd/releases/tag/v3.3)

Used xsltproc to translate /tests/files/passing.xml to /tests/files/referemce/pycsw_dist_translated.xml

Tested with and without file_name without crashing.

**Related issue**:

Closes #91 

**Suggested reviewer(s)**:

@mortenwh 

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.