### PR TITLE
Use tagged version of MMD

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,7 +10,7 @@ LABEL description="Discovery Metadata Catalog Ingestor used in the S-ENDA projec
 ARG DMCI_VERSION=main
 ARG DMCI_REPO=https://github.com/metno/discovery-metadata-catalog-ingestor
 ARG MMD_REPO=https://github.com/metno/mmd
-ARG MMD_VERSION=master
+ARG MMD_VERSION=v3.4
 
 # Set config file for dmci
 ENV DMCI_CONFIG=/config.yaml


### PR DESCRIPTION
**Summary**:

Dockerfile uses tagged version of MMD, to not build unready versions of dmci.

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.