### PR TITLE
Get back to 100% test coverage

### DIFF
--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -177,8 +177,8 @@ class Worker():
         """
         self._file_metadata_id = None
         self._namespace = None
-        fileUUID = None
-        namespace = None
+        fileUUID = ""
+        namespace = ""
         for xml_entry in xml_doc:
             local = etree.QName(xml_entry)
             if local.localname == "metadata_identifier":
@@ -189,19 +189,14 @@ class Worker():
                     return False
                 namespace, fileUUID = words
 
-                if len(namespace) == 0 or len(fileUUID) == 0:
-                    logger.warning("metadata_identifier has a ':'-character, but is malformed")
-                    logger.warning("metadata_identifier should be formed as namespace:UUID")
-                    return False
-
                 logger.info("XML file metadata_identifier namespace:%s" % namespace)
                 logger.info("XML file metadata_identifier UUID: %s" % fileUUID)
                 break
 
-        if fileUUID is None:
+        if fileUUID == "":
             logger.warning("No UUID found in XML file")
             return False
-        if namespace is None:
+        if namespace == "":
             logger.warning("No namespace found in XML file")
             return False
 

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -173,11 +173,18 @@ class Worker():
 
     def _extract_metadata_id(self, xml_doc):
         """Extract the metadata_identifier from the xml object and set
-        the class variable.
+        the class variables namespace and file_metadata_id.
+
+        Returns
+        -------
+        status : bool
+            True if both namespace and metadata_id is found, False
+            if either is missing, or if metadata_id can not be cast
+            as UUID type
         """
         self._file_metadata_id = None
         self._namespace = None
-        fileUUID = ""
+        file_uuid = ""
         namespace = ""
         for xml_entry in xml_doc:
             local = etree.QName(xml_entry)
@@ -187,13 +194,13 @@ class Worker():
                 if len(words) != 2:
                     logger.warning("metadata_identifier not formed as namespace:UUID")
                     return False
-                namespace, fileUUID = words
+                namespace, file_uuid = words
 
-                logger.info("XML file metadata_identifier namespace:%s" % namespace)
-                logger.info("XML file metadata_identifier UUID: %s" % fileUUID)
+                logger.info("XML file metadata_identifier namespace:%s", namespace)
+                logger.info("XML file metadata_identifier UUID: %s", file_uuid)
                 break
 
-        if fileUUID == "":
+        if file_uuid == "":
             logger.warning("No UUID found in XML file")
             return False
         if namespace == "":
@@ -201,10 +208,10 @@ class Worker():
             return False
 
         try:
-            self._file_metadata_id = uuid.UUID(fileUUID)
-            logger.debug("File UUID: %s" % str(fileUUID))
+            self._file_metadata_id = uuid.UUID(file_uuid)
+            logger.debug("File UUID: %s", str(file_uuid))
         except Exception as e:
-            logger.error("Could not parse UUID: '%s'" % str(fileUUID))
+            logger.error("Could not parse UUID: '%s'", str(file_uuid))
             logger.error(str(e))
             return False
         self._namespace = namespace

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -189,6 +189,11 @@ class Worker():
                     return False
                 namespace, fileUUID = words
 
+                if len(namespace) == 0 or len(fileUUID) == 0:
+                    logger.warning("metadata_identifier has a ':'-character, but is malformed")
+                    logger.warning("metadata_identifier should be formed as namespace:UUID")
+                    return False
+
                 logger.info("XML file metadata_identifier namespace:%s" % namespace)
                 logger.info("XML file metadata_identifier UUID: %s" % fileUUID)
                 break

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -219,6 +219,7 @@ def testApiWorker_ExtractMetaDataID(filesDir, mockXml):
         '</mmd:mmd>'
     )%(":a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b")
 
+    # format "test:no:a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b" is wrong (should be "test.no:UUID")
     namespaced_UUID_too_many = (
         '<mmd:mmd xmlns:mmd="http://www.met.no/schema/mmd" xmlns:gml="http://www.opengis.net/gml">'
         '  <mmd:metadata_identifier>%s</mmd:metadata_identifier>'

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -210,7 +210,7 @@ def testApiWorker_ExtractMetaDataID(filesDir, mockXml):
         '</mmd:mmd>'
     )%("a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b")
 
-    # ":a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b".split(":") returns two strings: 
+    # ":a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b".split(":") returns two strings:
     # "" and "a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b"
     # This test invokes empty return for namespace
     namespaced_UUID_empty_return = (

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -210,6 +210,9 @@ def testApiWorker_ExtractMetaDataID(filesDir, mockXml):
         '</mmd:mmd>'
     )%("a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b")
 
+    # ":a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b".split(":") returns two strings: 
+    # "" and "a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b"
+    # This test invokes empty return for namespace
     namespaced_UUID_empty_return = (
         '<mmd:mmd xmlns:mmd="http://www.met.no/schema/mmd" xmlns:gml="http://www.opengis.net/gml">'
         '  <mmd:metadata_identifier>%s</mmd:metadata_identifier>'

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -210,7 +210,13 @@ def testApiWorker_ExtractMetaDataID(filesDir, mockXml):
         '</mmd:mmd>'
     )%("a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b")
 
-    namespaced_UUID_bad = (
+    namespaced_UUID_empty_return = (
+        '<mmd:mmd xmlns:mmd="http://www.met.no/schema/mmd" xmlns:gml="http://www.opengis.net/gml">'
+        '  <mmd:metadata_identifier>%s</mmd:metadata_identifier>'
+        '</mmd:mmd>'
+    )%(":a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b")
+
+    namespaced_UUID_too_many = (
         '<mmd:mmd xmlns:mmd="http://www.met.no/schema/mmd" xmlns:gml="http://www.opengis.net/gml">'
         '  <mmd:metadata_identifier>%s</mmd:metadata_identifier>'
         '</mmd:mmd>'
@@ -230,8 +236,14 @@ def testApiWorker_ExtractMetaDataID(filesDir, mockXml):
     assert tstWorker._file_metadata_id is None
     assert tstWorker._namespace is None
 
+    passXML = lxml.etree.fromstring(bytes(namespaced_UUID_empty_return, "utf-8"))
+    tstWorker = Worker("insert", passFile, None)
+    assert tstWorker._extract_metadata_id(passXML) is False
+    assert tstWorker._file_metadata_id is None
+    assert tstWorker._namespace is None
+
     # MMD with invalid namespace
-    passXML = lxml.etree.fromstring(bytes(namespaced_UUID_bad, "utf-8"))
+    passXML = lxml.etree.fromstring(bytes(namespaced_UUID_too_many, "utf-8"))
     tstWorker = Worker("insert", passFile, None)
     assert tstWorker._extract_metadata_id(passXML) is False
     assert tstWorker._file_metadata_id is None


### PR DESCRIPTION
**Summary**:
Changes local types of fileUUID and namespace to str, to check edge case where namespace or fileUUID resolved to \"\". (Cases where metadata_identifier is either ":", "VALIDNS:" or ":VALIDUUID"
Also extended testing of missing namespace
Returns test-coverage to 100%

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.