### PR TITLE
Added uuid to the log if files do not parse correctly.

### DIFF
--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -130,6 +130,7 @@ class App(Flask):
                         path_to_parent_list=self._conf.path_to_parent_list)
         valid, msg = worker.validate(data)
         if not valid:
+            msg += f"\n UUID is : {file_uuid} \n "
             self._handle_persist_file(False, full_path, reject_path, msg)
             return msg, 400
 


### PR DESCRIPTION
**Summary**:Logs local uuid of files if it fails to parse

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.