### PR TITLE
Add logging to logger

### DIFF
--- a/dmci/distributors/pycsw_dist.py
+++ b/dmci/distributors/pycsw_dist.py
@@ -96,7 +96,7 @@ class PyCSWDist(Distributor):
         xml += b"</csw:Insert></csw:Transaction>"
         resp = requests.post(self._conf.csw_service_url, headers=headers, data=xml)
         status = self._get_transaction_status(self.TOTAL_INSERTED, resp)
-        logging.debug("Insert status: " + str(status) + ". With response: " + resp.text)
+        logger.debug("Insert status: " + str(status) + ". With response: " + resp.text)
         return status, resp.text
 
     def _update(self):
@@ -136,7 +136,7 @@ class PyCSWDist(Distributor):
         ) % (self._translate(), identifier.encode(encoding="utf-8"))
         resp = requests.post(self._conf.csw_service_url, headers=headers, data=xml)
         status = self._get_transaction_status(self.TOTAL_UPDATED, resp)
-
+        logger.debug("Update status: " + str(status) + ". With response: " + resp.text)
         return status, resp.text
 
     def _delete(self):
@@ -169,7 +169,7 @@ class PyCSWDist(Distributor):
         ) % identifier
         resp = requests.post(self._conf.csw_service_url, headers=headers, data=xml_as_string)
         status = self._get_transaction_status(self.TOTAL_DELETED, resp)
-
+        logger.debug("Delete status: " + str(status) + ". With response: " + resp.text)
         return status, resp.text
 
     def _get_transaction_status(self, key, resp):


### PR DESCRIPTION
**Summary**: Fixes typo in pycsw_distributor, which called the debug from the logging package and not the initialized logger-object

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.