### PR TITLE
add /dataset/ in the landing page path 

### DIFF
--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -252,7 +252,8 @@ class Worker:
             matchstring_end = b"\n</mmd:mmd>\n"
             end_mod = str.encode(
                 f"\n  <mmd:related_information>\n    <mmd:type>Dataset landing page</mmd:type>"
-                f"\n    <mmd:description/>\n    <mmd:resource>{catalog_url}/dataset/{uuid}</mmd:resource>"
+                f"\n    <mmd:description/>"
+                f"\n    <mmd:resource>{catalog_url}/dataset/{uuid}</mmd:resource>"
                 f"\n  </mmd:related_information>\n</mmd:mmd>\n"
             )
             data_mod = re.sub(matchstring_end, end_mod, data)

--- a/dmci/api/worker.py
+++ b/dmci/api/worker.py
@@ -252,7 +252,7 @@ class Worker:
             matchstring_end = b"\n</mmd:mmd>\n"
             end_mod = str.encode(
                 f"\n  <mmd:related_information>\n    <mmd:type>Dataset landing page</mmd:type>"
-                f"\n    <mmd:description/>\n    <mmd:resource>{catalog_url}/{uuid}</mmd:resource>"
+                f"\n    <mmd:description/>\n    <mmd:resource>{catalog_url}/dataset/{uuid}</mmd:resource>"
                 f"\n  </mmd:related_information>\n</mmd:mmd>\n"
             )
             data_mod = re.sub(matchstring_end, end_mod, data)
@@ -267,7 +267,7 @@ class Worker:
             found_datasetlandingpage = match_datasetlandingpage.group(1)
             datasetlandingpage_mod = str.encode(
                 f"\n    <mmd:description/>\n    "
-                f"<mmd:resource>{catalog_url}/{uuid}</mmd:resource>\n  "
+                f"<mmd:resource>{catalog_url}/dataset/{uuid}</mmd:resource>\n  "
             )
             data_mod = re.sub(found_datasetlandingpage,
                               datasetlandingpage_mod, data)

--- a/tests/test_api/test_worker.py
+++ b/tests/test_api/test_worker.py
@@ -401,7 +401,7 @@ def testApiWorker_AddLandingPage(filesDir):
         filesDir, "api", "passing_wrelatedinfo_nolandingpage.xml"
     )
 
-    catalog_url = "https://data.met.no/dataset"
+    catalog_url = "https://data.met.no"
     uuid = "a1ddaf0f-cae0-4a15-9b37-3468e9cb1a2b"
 
     data_wo_landingpage = bytes(readFile(passFile), "utf-8")


### PR DESCRIPTION
(since catalog_url in the kubernetes config is e.g. "https://data.met.no/" not "https://data.met.no/dataset")
fixes #182 

**Summary**:

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.