### PR TITLE
Change metadata_id to UUID in solrDist

### DIFF
--- a/dmci/distributors/distributor.py
+++ b/dmci/distributors/distributor.py
@@ -120,8 +120,7 @@ class Distributor():
     @staticmethod
     def _construct_identifier(namespace, metadata_id):
         """Helper function to construct identifier from namespace and
-        UUID. Currently accepts empty namespaces, but later will only
-        accept correctly formed namespaced UUID
+        UUID. Currently only accepts correctly formed namespaced UUID
 
         Parameters
         ----------
@@ -136,8 +135,6 @@ class Distributor():
             namespace:UUID or just UUID if namespace is empty.
         """
         if namespace != "":
-            identifier = namespace + ":" + str(metadata_id)
-        else:
-            identifier = str(metadata_id)
-        return identifier
+            return namespace + ":" + str(metadata_id)
+        raise ValueError("Namespace cannot be empty")
 # END Class Distributor

--- a/dmci/distributors/solr_dist.py
+++ b/dmci/distributors/solr_dist.py
@@ -39,9 +39,9 @@ class SolRDist(Distributor):
     TOTAL_UPDATED = "total_updated"
     STATUS = [TOTAL_DELETED, TOTAL_INSERTED, TOTAL_UPDATED]
 
-    def __init__(self, cmd, xml_file=None, metadata_id=None, worker=None, **kwargs):
+    def __init__(self, cmd, xml_file=None, metadata_UUID=None, worker=None, **kwargs):
 
-        super().__init__(cmd, xml_file, metadata_id, worker, **kwargs)
+        super().__init__(cmd, xml_file, metadata_UUID, worker, **kwargs)
 
         self.authentication = self._init_authentication()
 

--- a/dmci/distributors/solr_dist.py
+++ b/dmci/distributors/solr_dist.py
@@ -152,7 +152,6 @@ class SolRDist(Distributor):
             identifier, commit=self._conf.commit_on_delete)
         logger.info("SolR delete status: %s. With response: %s" %
                     (str(status), str(msg)))
-        # return status, message
         return status, msg
 
 # END Class SolRDist

--- a/tests/test_dist/test_pycsw_dist.py
+++ b/tests/test_dist/test_pycsw_dist.py
@@ -27,6 +27,15 @@ from dmci.api.worker import Worker
 from dmci.distributors.pycsw_dist import PyCSWDist
 
 
+class mockResp:
+    text = "Mock response"
+    status_code = 200
+
+
+class mockWorker:
+    _namespace = ""
+
+
 @pytest.mark.dist
 def testDistPyCSW_Init(tmpUUID):
     """Test the PyCSWDist class init."""
@@ -53,9 +62,6 @@ def testDistPyCSW_Run(tmpUUID):
 @pytest.mark.dist
 def testDistPyCSW_Insert(monkeypatch, mockXml, mockXslt):
     """Test insert commands via run()."""
-    class mockResp:
-        text = "Mock response"
-        status_code = 200
 
     # Insert returns True
     with monkeypatch.context() as mp:
@@ -85,9 +91,6 @@ def testDistPyCSW_Insert(monkeypatch, mockXml, mockXslt):
 @pytest.mark.dist
 def testDistPyCSW_Update(monkeypatch, mockXml, mockXslt, tmpUUID):
     """Test update commands via run()."""
-    class mockResp:
-        text = "Mock response"
-        status_code = 200
 
     tstWorker = Worker("update", None, None)
     tstWorker._file_metadata_id = tmpUUID
@@ -124,12 +127,6 @@ def testDistPyCSW_Update(monkeypatch, mockXml, mockXslt, tmpUUID):
 @pytest.mark.dist
 def testDistPyCSW_Delete(monkeypatch, mockXml, tmpUUID):
     """Test delete commands via run()."""
-    class mockResp:
-        text = "Mock response"
-        status_code = 200
-
-    class mockWorker:
-        _namespace = ""
 
     assert PyCSWDist("delete").run() == (False, "The run job is invalid")
     assert PyCSWDist("delete", xml_file=mockXml).run() == (False, "The run job is invalid")
@@ -140,13 +137,12 @@ def testDistPyCSW_Delete(monkeypatch, mockXml, tmpUUID):
             "dmci.distributors.pycsw_dist.requests.post", lambda *a, **k: mockResp
         )
         mp.setattr(PyCSWDist, "_get_transaction_status", lambda *a: True)
-        res = PyCSWDist("delete", metadata_UUID=tmpUUID, worker=mockWorker).run()
-        assert res == (True, "Mock response")
+        with pytest.raises(ValueError):
+            res = PyCSWDist("delete", metadata_UUID=tmpUUID, worker=mockWorker).run()
+
         mockWorker._namespace = "test.no"
         res = PyCSWDist("delete", metadata_UUID=tmpUUID, worker=mockWorker).run()
         assert res == (True, "Mock response")
-
-    mockWorker._namespace = ""
 
     # delete returns false
     with monkeypatch.context() as mp:
@@ -154,6 +150,7 @@ def testDistPyCSW_Delete(monkeypatch, mockXml, tmpUUID):
             "dmci.distributors.pycsw_dist.requests.post", lambda *a, **k: mockResp
         )
         mp.setattr(PyCSWDist, "_get_transaction_status", lambda *a: False)
+        mockWorker._namespace = "test.no"
         res = PyCSWDist("delete", metadata_UUID=tmpUUID, worker=mockWorker).run()
         assert res == (False, "Mock response")
 

--- a/tests/test_dist/test_solr_dist.py
+++ b/tests/test_dist/test_solr_dist.py
@@ -65,10 +65,10 @@ def testDistSolR_Init(tmpUUID):
     """Test the SolRDist class init."""
     # Check that it initialises properly by running some of the simple
     # Distributor class tests
-    assert SolRDist("insert", metadata_id=tmpUUID).is_valid() is False
-    assert SolRDist("update", metadata_id=tmpUUID).is_valid() is False
-    assert SolRDist("delete", metadata_id=tmpUUID).is_valid() is True
-    assert SolRDist("blabla", metadata_id=tmpUUID).is_valid() is False
+    assert SolRDist("insert", metadata_UUID=tmpUUID).is_valid() is False
+    assert SolRDist("update", metadata_UUID=tmpUUID).is_valid() is False
+    assert SolRDist("delete", metadata_UUID=tmpUUID).is_valid() is True
+    assert SolRDist("blabla", metadata_UUID=tmpUUID).is_valid() is False
 
 
 @pytest.mark.dist
@@ -243,7 +243,7 @@ def testDistSolR_AddDocExists(mockXml, monkeypatch):
 def testDistSolR_Delete(monkeypatch):
     """Test the SolRDist class delete actions."""
     id = "no.met.dev:250ba38f-1081-4669-a429-f378c569db32"
-    tstDist = SolRDist("delete", metadata_id=id, worker=mockWorker)
+    tstDist = SolRDist("delete", metadata_UUID=id, worker=mockWorker)
 
     # Test delete exception Sucess
     with monkeypatch.context() as mp:


### PR DESCRIPTION
**Summary**: 

- Fixes an error in SolrDistribute, where it will get multiple metadata_UUID, due to positional and keyword arguments
- Fixes enforcing of namespace on the construct-identifier-function for the worker-class.
- Rewrote tests for SolrDistribute.delete functionality

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.