### PR TITLE
Namespace checks

### DIFF
--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -272,7 +272,7 @@ class App(Flask):
             return None, None, f"Cannot convert to UUID: {uuid_str}"
 
         # Check that the namespace is correct
-        if env_string is None:  # we are in prod
+        if not env_string:  # we are in prod
             if ".staging" in md_namespace or ".dev" in md_namespace:
                 return (
                     None,

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -236,7 +236,7 @@ class App(Flask):
 
         # Check that the namespace is correct
         if not env_string:  # we are in prod
-            if 'staging' in md_namespace or 'dev' in md_namespace:
+            if ".staging" in md_namespace or ".dev" in md_namespace:
                 return (
                     None,
                     None,

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -235,7 +235,7 @@ class App(Flask):
             return None, None, f"Cannot convert to UUID: {uuid_str}"
 
         # Check that the namespace is correct
-        if not env_string:  # we are in prod
+        if env_string is None:  # we are in prod
             if ".staging" in md_namespace or ".dev" in md_namespace:
                 return (
                     None,

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -235,7 +235,14 @@ class App(Flask):
             return None, None, f"Cannot convert to UUID: {uuid_str}"
 
         # Check that the namespace is correct
-        if env_string is not None:
+        if not env_string:  # we are in prod
+            if 'staging' in md_namespace or 'dev' in md_namespace:
+                return (
+                    None,
+                    None,
+                    f"Dataset metadata_id namespace is wrong for production: {md_namespace}"
+                )
+        else:
             env = md_namespace.split(".")[-1]
             if env_string != env:
                 return None, None, f"Dataset metadata_id namespace is wrong: {env}"

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -272,7 +272,7 @@ class App(Flask):
             return None, None, f"Cannot convert to UUID: {uuid_str}"
 
         # Check that the namespace is correct
-        if not env_string:  # we are in prod
+        if env_string is None:  # we are in prod
             if ".staging" in md_namespace or ".dev" in md_namespace:
                 return (
                     None,

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -416,7 +416,7 @@ def testApiApp_CheckMetadataId():
     )
 
     # With namespace but the wrong one for prod environement
-    assert App._check_metadata_id("test.dev:"+testUUID, env_string="") == (None, None,
+    assert App._check_metadata_id("test.dev:"+testUUID, env_string=None) == (None, None,
                                                                            "Dataset metadata_id "
                                                                            "namespace is wrong "
                                                                            "for production: "

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -417,10 +417,10 @@ def testApiApp_CheckMetadataId():
 
     # With namespace but the wrong one for prod environement
     assert App._check_metadata_id("test.dev:"+testUUID, env_string=None) == (None, None,
-                                                                           "Dataset metadata_id "
-                                                                           "namespace is wrong "
-                                                                           "for production: "
-                                                                           "test.dev")
+                                                                             "Dataset metadata_id "
+                                                                             "namespace is wrong "
+                                                                             "for production: "
+                                                                             "test.dev")
     assert App._check_metadata_id("test.staging:"+testUUID) == (None, None,
                                                                 "Dataset metadata_id "
                                                                 "namespace is wrong "

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -339,11 +339,24 @@ def testApiApp_CheckMetadataId():
     # Without namespace
     assert App._check_metadata_id(testUUID) == (None, None,
                                                 "Input must be structured as <namespace>:<uuid>.")
+
     # With namespace, but not in accordance with the defined env_string
     assert App._check_metadata_id("test:"+testUUID, env_string="TEST") == (None, None,
                                                                            "Dataset metadata_id "
                                                                            "namespace is wrong: "
                                                                            "test")
+
+    # With namespace but the wrong one for prod environement
+    assert App._check_metadata_id("test.dev:"+testUUID, env_string="") == (None, None,
+                                                                           "Dataset metadata_id "
+                                                                           "namespace is wrong "
+                                                                           "for production: "
+                                                                           "test.dev")
+    assert App._check_metadata_id("test.staging:"+testUUID) == (None, None,
+                                                                "Dataset metadata_id "
+                                                                "namespace is wrong "
+                                                                "for production: "
+                                                                "test.staging")
 
     # With namespace, defined env_string, but present in call
     assert App._check_metadata_id("test.TEST:"+testUUID, env_string="TEST") == ("test.TEST",


### PR DESCRIPTION
**Summary**:
if there is no env_string we still need to check that the namespace does not contain a .dev or .staging, as it could be as a result of a mistake so far not prevented at the point of ingestion

**Related issue**: 
#229

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.