### PR TITLE
remove collector registry

### DIFF
--- a/container/wsgi.py
+++ b/container/wsgi.py
@@ -22,8 +22,7 @@ import sys
 
 from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
-from prometheus_client import make_wsgi_app, CollectorRegistry
-from prometheus_client.core import REGISTRY
+from prometheus_client import make_wsgi_app
 
 from dmci.api import App
 from dmci import CONFIG
@@ -32,8 +31,7 @@ if not CONFIG.readConfig(configFile=os.environ.get("DMCI_CONFIG", None)):
     sys.exit(1)
 
 app = App()
-REGISTRY.register(CollectorRegistry())
 app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
-    '/metrics': make_wsgi_app(REGISTRY)
+    '/metrics': make_wsgi_app()
 })
 GunicornPrometheusMetrics(app)


### PR DESCRIPTION
**Summary**: I think that the extra CollectorRegistry() broke the metrics, the standard flask collector does not work anymore at the moment https://dmci.s-enda-dev.k8s.met.no/metrics, so trying to remove it. testing with a local container still exposes everything so hard to tell if this will fix..

**Related issue**: #220

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.