### PR TITLE
back to GunicornPrometheusMetrics, CollectorRegistry, port 9200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,10 @@ ENTRYPOINT ["dumb-init", "--"]
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
 ENV prometheus_multiproc_dir /tmp
+ENV METRICS_PORT 9200
+EXPOSE 9200
+
+COPY container/gunicorn_prometheus_config.py /src/
 
 # Start application
-CMD gunicorn --worker-class sync --workers 5 --bind 0.0.0.0:8000 wsgi:app --keep-alive 5 --log-level info
+CMD gunicorn -c /src/gunicorn_prometheus_config.py --worker-class sync --workers 5 --bind 0.0.0.0:8000 wsgi:app --keep-alive 5 --log-level info

--- a/container/gunicorn_prometheus_config.py
+++ b/container/gunicorn_prometheus_config.py
@@ -1,0 +1,11 @@
+import os
+
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
+
+
+def when_ready(server):
+    GunicornPrometheusMetrics.start_http_server_when_ready(int(os.getenv('METRICS_PORT')))
+
+
+def child_exit(server, worker):
+    GunicornPrometheusMetrics.mark_process_dead_on_child_exit(worker.pid)

--- a/container/wsgi.py
+++ b/container/wsgi.py
@@ -20,7 +20,7 @@ limitations under the License.
 import os
 import sys
 
-from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+from prometheus_flask_exporter.multiprocess import GunicornPrometheusMetrics
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from prometheus_client import make_wsgi_app, CollectorRegistry
 from prometheus_client.core import REGISTRY
@@ -35,6 +35,6 @@ if not CONFIG.readConfig(configFile=os.environ.get("DMCI_CONFIG", None)):
 app = App()
 REGISTRY.register(CollectorRegistry())
 app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
-    '/metrics': make_wsgi_app(REGISTRY)
+    '/metrics': make_wsgi_app(registry=REGISTRY)
 })
-GunicornInternalPrometheusMetrics(app, path='/metrics', registry=REGISTRY)
+GunicornPrometheusMetrics(app, path='/metrics', registry=REGISTRY)


### PR DESCRIPTION
**Summary**: this again for me exposes all the metrics at port 9200 when I run the container with docker....

**Related issue**: #220 

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.