### PR TITLE
fix string name

### DIFF
--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 OK_RETURN = "Everything is OK"
 
 FILE_DIST_FAIL = Counter("failed_file_dist", "Number of failed file_dist", ["path"])
-CSW_DIST_FAIL = Counter("failed_csw_dist", "Number of failed csw_dist", ["path"])
+CSW_DIST_FAIL = Counter("failed_pycsw_dist", "Number of failed csw_dist", ["path"])
 SOLR_DIST_FAIL = Counter("failed_solr_dist", "Number of failed solr_dist", ["path"])
 
 

--- a/dmci/api/app.py
+++ b/dmci/api/app.py
@@ -76,7 +76,7 @@ class App(Flask):
             if failed:
                 if "file" in failed:
                     FILE_DIST_FAIL.labels(path=request.path).inc()
-                if "csw" in failed:
+                if "pycsw" in failed:
                     CSW_DIST_FAIL.labels(path=request.path).inc()
                 if "solr" in failed:
                     SOLR_DIST_FAIL.labels(path=request.path).inc()
@@ -89,7 +89,7 @@ class App(Flask):
             if failed:
                 if "file" in failed:
                     FILE_DIST_FAIL.labels(path=request.path).inc()
-                if "csw" in failed:
+                if "pycsw" in failed:
                     CSW_DIST_FAIL.labels(path=request.path).inc()
                 if "solr" in failed:
                     SOLR_DIST_FAIL.labels(path=request.path).inc()

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -240,7 +240,7 @@ def testApiApp_InsertUpdateRequests(client, monkeypatch):
             "failed_file_dist_total", {"path": "/v1/insert"}
         )
         after_csw = REGISTRY.get_sample_value(
-            "failed_csw_dist_total", {"path": "/v1/insert"}
+            "failed_pycsw_dist_total", {"path": "/v1/insert"}
         )
         after_solr = REGISTRY.get_sample_value(
             "failed_solr_dist_total", {"path": "/v1/insert"}
@@ -254,7 +254,7 @@ def testApiApp_InsertUpdateRequests(client, monkeypatch):
             "failed_file_dist_total", {"path": "/v1/update"}
         )
         after_csw = REGISTRY.get_sample_value(
-            "failed_csw_dist_total", {"path": "/v1/update"}
+            "failed_pycsw_dist_total", {"path": "/v1/update"}
         )
         after_solr = REGISTRY.get_sample_value(
             "failed_solr_dist_total", {"path": "/v1/update"}

--- a/tests/test_api/test_app.py
+++ b/tests/test_api/test_app.py
@@ -227,7 +227,7 @@ def testApiApp_InsertUpdateRequests(client, monkeypatch):
 
     # Distribution fails, metrics are incremented
     with monkeypatch.context() as mp:
-        f = ["file", "solr", "csw"]
+        f = ["file", "solr", "pycsw"]
         s = ["C"]
         e = ["Reason A", "Reason B", "Reason C"]
         mp.setattr("dmci.api.app.Worker.validate", lambda *a: (True, "", MOCK_XML))


### PR DESCRIPTION
**Summary**: the string returned in case pycsw distributor fails was wrong

**Related issue**: #220 

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.